### PR TITLE
fix(deps): patch security-audit advisories (crossbeam-epoch, rand)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -410,9 +410,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1352,9 +1352,9 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_core 0.9.3",
 ]


### PR DESCRIPTION
## Problem

The **Security audit** CI job (`cargo audit`) is red on `main`. It reports 4 entries; only one is a *vulnerability* (which is what fails the job — `denyWarnings: false` means warnings don't fail):

| Advisory | Crate | Kind |
|---|---|---|
| [RUSTSEC-2026-0204](https://rustsec.org/advisories/RUSTSEC-2026-0204) | `crossbeam-epoch` 0.9.18 | **vulnerability** — invalid pointer dereference in `fmt::Pointer` impl (fix ≥ 0.9.20) |
| [RUSTSEC-2026-0097](https://rustsec.org/advisories/RUSTSEC-2026-0097) | `rand` 0.9.2 | unsound (custom logger using `rand::rng()`) |
| [RUSTSEC-2026-0012](https://rustsec.org/advisories/RUSTSEC-2026-0012) | `keccak` 0.1.5 | unsound (opt-in ARMv8 asm backend) |
| — | `keccak` 0.1.5 | yanked |

## Fix

Semver-compatible **Cargo.lock**-only bumps (no `Cargo.toml` change):

- `crossbeam-epoch` 0.9.18 → **0.9.20** (transitive via `rayon`) — clears the vulnerability
- `rand` 0.9.2 → **0.9.4** — clears the unsound warning

`keccak` 0.1.5 is pinned by `merlin` 3.0.0 (via the `bulletproofs` fork) and cannot move without changing that fork; it is warnings-only (unsound backend is opt-in and unused, plus yanked), so it does not fail CI.

After the bump, `cargo audit` exits 0.

> Mirrors dwallet-labs/cryptography-private#603 (identical lockfile bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)