### PR TITLE
fix(2pc-mpc/mock): pp-derived Schnorr-AHE presign commitment; enforce threshold in mock advance

### DIFF
--- a/2pc-mpc/src/mock.rs
+++ b/2pc-mpc/src/mock.rs
@@ -10,7 +10,9 @@
 //! Under the `unsafe_mock` feature the exported protocol party/`Protocol` aliases are redirected to
 //! the mock party types defined here (see `crate::mock::{dkg, ecdsa, schnorr, vss, network_dkg}`);
 //! the real protocol `advance`/method bodies are left completely untouched. Each mock party
-//! finalizes in a single round, deterministically, from the common public inputs alone.
+//! simulates its real protocol's round structure — trivial [`MOCK_HONEST_MESSAGE`] rounds with
+//! malicious-sender detection and threshold enforcement (see [`mock_advance_result`]) — and
+//! finalizes on the last round, deterministically, from the common public inputs alone.
 //!
 //! ## What it gives up
 //! **All security.** Every dWallet uses the SAME constant signing key `x = 42`

--- a/2pc-mpc/src/mock.rs
+++ b/2pc-mpc/src/mock.rs
@@ -26,13 +26,13 @@ pub(crate) mod schnorr;
 mod timings;
 pub(crate) mod vss;
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use crypto_bigint::Uint;
 
 use group::helpers::DeduplicateAndSort;
 use group::{GroupElement as _, PartyID, PrimeGroupElement};
-use mpc::AsynchronousRoundResult;
+use mpc::{AsynchronousRoundResult, WeightedThresholdAccessStructure};
 
 /// The magic value every honest party's mock protocol message carries. The mock
 /// parties simulate the real round structure (advancing round-by-round, finalizing
@@ -74,12 +74,31 @@ pub(crate) fn mock_round_bookkeeping(
 /// [`AsynchronousRoundResult::Finalize`] with the outputs from `finalize` (called
 /// only on the final round; its error is propagated). Threads the detected
 /// `malicious_parties` through either arm.
-pub(crate) fn mock_advance_result<PrivateOutput, PublicOutput, Error>(
+///
+/// Mimics the real protocols' threshold-not-reached behavior: an advance first
+/// filters protocol-invalid (malicious) contributions, then requires the remaining
+/// senders of the latest completed round to form an authorized subset — otherwise it
+/// aborts with [`mpc::ErrorKind::ThresholdNotReached`], which the
+/// guaranteed-output-delivery layer converts into a `ThresholdNotReached` message and
+/// a retried advance (attributed to the previous round, see
+/// [`mock_round_causing_threshold_not_reached`]).
+pub(crate) fn mock_advance_result<PrivateOutput, PublicOutput, Error: From<mpc::Error>>(
+    access_structure: &WeightedThresholdAccessStructure,
     messages: &[HashMap<PartyID, u64>],
     total_rounds: usize,
     finalize: impl FnOnce() -> Result<(PrivateOutput, PublicOutput), Error>,
 ) -> Result<AsynchronousRoundResult<u64, PrivateOutput, PublicOutput>, Error> {
     let (malicious_parties, is_final_round) = mock_round_bookkeeping(messages, total_rounds);
+    if let Some(latest_round_messages) = messages.last() {
+        let honest_senders = latest_round_messages
+            .keys()
+            .filter(|party_id| !malicious_parties.contains(party_id))
+            .copied()
+            .collect::<HashSet<_>>();
+        access_structure
+            .is_authorized_subset(&honest_senders)
+            .map_err(Error::from)?;
+    }
     if is_final_round {
         let (private_output, public_output) = finalize()?;
         Ok(AsynchronousRoundResult::Finalize {

--- a/2pc-mpc/src/mock/dkg.rs
+++ b/2pc-mpc/src/mock/dkg.rs
@@ -387,7 +387,7 @@ where
     fn advance(
         _session_id: CommitmentSizedNumber,
         _party_id: PartyID,
-        _access_structure: &WeightedThresholdAccessStructure,
+        access_structure: &WeightedThresholdAccessStructure,
         messages: Vec<std::collections::HashMap<PartyID, Self::Message>>,
         _private_input: Option<Self::PrivateInput>,
         public_input: &Self::PublicInput,
@@ -397,7 +397,7 @@ where
         Self::Error,
     > {
         // dwallet DKG decentralized party is a 2-round protocol.
-        crate::mock::mock_advance_result(&messages, 2, || {
+        crate::mock::mock_advance_result(access_structure, &messages, 2, || {
             Ok((
                 (),
                 mock_dkg_output::<SCALAR_LIMBS, GroupElement, _, _>(

--- a/2pc-mpc/src/mock/ecdsa.rs
+++ b/2pc-mpc/src/mock/ecdsa.rs
@@ -348,7 +348,7 @@ where
     fn advance(
         session_id: CommitmentSizedNumber,
         _party_id: PartyID,
-        _access_structure: &WeightedThresholdAccessStructure,
+        access_structure: &WeightedThresholdAccessStructure,
         messages: Vec<HashMap<PartyID, Self::Message>>,
         _private_input: Option<Self::PrivateInput>,
         public_input: &Self::PublicInput,
@@ -358,7 +358,7 @@ where
         Self::Error,
     > {
         // ECDSA presign decentralized party is a 4-round protocol.
-        crate::mock::mock_advance_result(&messages, 4, || {
+        crate::mock::mock_advance_result(access_structure, &messages, 4, || {
             let protocol_public_parameters = &*public_input.protocol_public_parameters;
             let identity_point = GroupElement::neutral_from_public_parameters(
                 &protocol_public_parameters.group_public_parameters,
@@ -646,7 +646,7 @@ where
     fn advance(
         _session_id: CommitmentSizedNumber,
         _party_id: PartyID,
-        _access_structure: &WeightedThresholdAccessStructure,
+        access_structure: &WeightedThresholdAccessStructure,
         messages: Vec<HashMap<PartyID, Self::Message>>,
         _private_input: Option<Self::PrivateInput>,
         public_input: &Self::PublicInput,
@@ -656,7 +656,7 @@ where
         Self::Error,
     > {
         // ECDSA sign decentralized party is a 2-round protocol (happy-flow).
-        crate::mock::mock_advance_result(&messages, 2, || {
+        crate::mock::mock_advance_result(access_structure, &messages, 2, || {
             let protocol_public_parameters = &*public_input.protocol_public_parameters;
             let signature = mock_sign::<SCALAR_LIMBS, GroupElement>(
                 &public_input.message,
@@ -948,7 +948,7 @@ where
     fn advance(
         _session_id: CommitmentSizedNumber,
         _party_id: PartyID,
-        _access_structure: &WeightedThresholdAccessStructure,
+        access_structure: &WeightedThresholdAccessStructure,
         messages: Vec<HashMap<PartyID, Self::Message>>,
         _private_input: Option<Self::PrivateInput>,
         public_input: &Self::PublicInput,
@@ -959,7 +959,7 @@ where
     > {
         // The fused ECDSA DKG+sign decentralized party shares the sign protocol's 2-round
         // (happy-flow) structure.
-        crate::mock::mock_advance_result(&messages, 2, || {
+        crate::mock::mock_advance_result(access_structure, &messages, 2, || {
             let protocol_public_parameters = &*public_input.protocol_public_parameters;
             let dkg_output = crate::mock::dkg::mock_dkg_output::<SCALAR_LIMBS, GroupElement, _, _>(
                 protocol_public_parameters,

--- a/2pc-mpc/src/mock/network_dkg.rs
+++ b/2pc-mpc/src/mock/network_dkg.rs
@@ -369,7 +369,7 @@ impl AsynchronouslyAdvanceable for MockNetworkDKGParty {
     fn advance(
         _session_id: CommitmentSizedNumber,
         _tangible_party_id: PartyID,
-        _access_structure: &WeightedThresholdAccessStructure,
+        access_structure: &WeightedThresholdAccessStructure,
         messages: Vec<HashMap<PartyID, Self::Message>>,
         _private_input: Option<Self::PrivateInput>,
         _public_input: &Self::PublicInput,
@@ -379,7 +379,7 @@ impl AsynchronouslyAdvanceable for MockNetworkDKGParty {
         Self::Error,
     > {
         // The network-DKG decentralized party is a 7-round protocol.
-        crate::mock::mock_advance_result(&messages, 7, || {
+        crate::mock::mock_advance_result(access_structure, &messages, 7, || {
             Ok(((), mock_network_dkg_public_output().clone()))
         })
     }
@@ -422,7 +422,7 @@ impl AsynchronouslyAdvanceable for MockNetworkReconfigurationParty {
         Self::Error,
     > {
         // The network-reconfiguration decentralized party is a 4-round protocol.
-        crate::mock::mock_advance_result(&messages, 4, || {
+        crate::mock::mock_advance_result(current_access_structure, &messages, 4, || {
             Ok((
                 (),
                 mock_network_reconfiguration_public_output(current_access_structure),
@@ -466,7 +466,7 @@ impl AsynchronouslyAdvanceable for MockNetworkDKGPartyV2 {
     fn advance(
         _session_id: CommitmentSizedNumber,
         _tangible_party_id: PartyID,
-        _access_structure: &WeightedThresholdAccessStructure,
+        access_structure: &WeightedThresholdAccessStructure,
         messages: Vec<HashMap<PartyID, Self::Message>>,
         _private_input: Option<Self::PrivateInput>,
         _public_input: &Self::PublicInput,
@@ -476,7 +476,7 @@ impl AsynchronouslyAdvanceable for MockNetworkDKGPartyV2 {
         Self::Error,
     > {
         // The backward-compatible (V2) network-DKG decentralized party is a 4-round protocol.
-        crate::mock::mock_advance_result(&messages, 4, || {
+        crate::mock::mock_advance_result(access_structure, &messages, 4, || {
             Ok(((), mock_network_dkg_public_output().core.clone()))
         })
     }
@@ -521,7 +521,7 @@ impl AsynchronouslyAdvanceable for MockNetworkReconfigurationPartyV2 {
     > {
         // The backward-compatible (V2) network-reconfiguration decentralized party is a 4-round
         // protocol.
-        crate::mock::mock_advance_result(&messages, 4, || {
+        crate::mock::mock_advance_result(current_access_structure, &messages, 4, || {
             Ok((
                 (),
                 mock_network_reconfiguration_public_output(current_access_structure).core,

--- a/2pc-mpc/src/mock/schnorr.rs
+++ b/2pc-mpc/src/mock/schnorr.rs
@@ -117,9 +117,10 @@ type RealPresignAsyncSchnorrParty<
     GroupElement,
 >;
 
-/// INSECURE mock of the Schnorr-AHE presign party — finalizes round 1 with a single dummy presign
-/// (identity nonce points, reused ciphertexts, dummy commitment); the mocked constant-nonce sign
-/// ignores the presign entirely.
+/// INSECURE mock of the Schnorr-AHE presign party — simulates the real 2-round structure and
+/// finalizes with a single dummy presign (identity nonce points, reused ciphertexts, and the
+/// pp-derived global-output commitment, which the real centralized sign party validates); the
+/// mocked constant-nonce sign ignores the presign entirely.
 pub struct MockPresignAsyncSchnorrParty<
     const SCALAR_LIMBS: usize,
     const FUNDAMENTAL_DISCRIMINANT_LIMBS: usize,
@@ -343,7 +344,7 @@ where
     fn advance(
         session_id: CommitmentSizedNumber,
         _party_id: PartyID,
-        _access_structure: &WeightedThresholdAccessStructure,
+        access_structure: &WeightedThresholdAccessStructure,
         messages: Vec<HashMap<PartyID, Self::Message>>,
         _private_input: Option<Self::PrivateInput>,
         public_input: &Self::PublicInput,
@@ -353,7 +354,7 @@ where
         Self::Error,
     > {
         // Schnorr-AHE presign decentralized party is a 2-round protocol.
-        crate::mock::mock_advance_result(&messages, 2, || {
+        crate::mock::mock_advance_result(access_structure, &messages, 2, || {
             let protocol_public_parameters = &*public_input.protocol_public_parameters;
             let identity_point = GroupElement::neutral_from_public_parameters(
                 &protocol_public_parameters.group_public_parameters,
@@ -367,7 +368,13 @@ where
                 encryption_of_decentralized_party_nonce_share_second_part: dummy_ciphertext,
                 decentralized_party_nonce_public_share_first_part: identity_point.clone(),
                 decentralized_party_nonce_public_share_second_part: identity_point,
-                global_decentralized_party_output_commitment: CommitmentSizedNumber::ZERO,
+                // Must be the real pp-derived commitment, not a dummy: the Schnorr-AHE
+                // `Presign` is unversioned, so `Presign == pp` always compares this field
+                // (see `schnorr::ahe::presign`), and the *real* centralized sign party —
+                // which the mock protocols deliberately keep — rejects the presign with
+                // `InvalidParameters` on mismatch.
+                global_decentralized_party_output_commitment: protocol_public_parameters
+                    .global_decentralized_party_output_commitment()?,
             };
             Ok(((), vec![presign]))
         })
@@ -696,7 +703,7 @@ where
     fn advance(
         _session_id: CommitmentSizedNumber,
         _party_id: PartyID,
-        _access_structure: &WeightedThresholdAccessStructure,
+        access_structure: &WeightedThresholdAccessStructure,
         messages: Vec<HashMap<PartyID, Self::Message>>,
         _private_input: Option<Self::PrivateInput>,
         public_input: &Self::PublicInput,
@@ -706,7 +713,7 @@ where
         Self::Error,
     > {
         // Schnorr-AHE sign decentralized party is a 2-round protocol (happy-flow).
-        crate::mock::mock_advance_result(&messages, 2, || {
+        crate::mock::mock_advance_result(access_structure, &messages, 2, || {
             let protocol_public_parameters = &*public_input.protocol_public_parameters;
             let signature = mock_sign::<SCALAR_LIMBS, GroupElement>(
                 &public_input.message,
@@ -1017,7 +1024,7 @@ where
     fn advance(
         _session_id: CommitmentSizedNumber,
         _party_id: PartyID,
-        _access_structure: &WeightedThresholdAccessStructure,
+        access_structure: &WeightedThresholdAccessStructure,
         messages: Vec<HashMap<PartyID, Self::Message>>,
         _private_input: Option<Self::PrivateInput>,
         public_input: &Self::PublicInput,
@@ -1028,7 +1035,7 @@ where
     > {
         // The fused Schnorr DKG+sign decentralized party shares the sign protocol's 2-round
         // (happy-flow) structure.
-        crate::mock::mock_advance_result(&messages, 2, || {
+        crate::mock::mock_advance_result(access_structure, &messages, 2, || {
             let protocol_public_parameters = &*public_input.protocol_public_parameters;
             let dkg_output = crate::mock::dkg::mock_dkg_output::<SCALAR_LIMBS, GroupElement, _, _>(
                 protocol_public_parameters,

--- a/2pc-mpc/src/mock/timings.rs
+++ b/2pc-mpc/src/mock/timings.rs
@@ -154,9 +154,13 @@ fn mock_protocol_timings_report() {
         dkg_output: None,
         protocol_public_parameters: Arc::new(protocol_public_parameters.clone()),
     };
-    // ECDSA presign is a 4-round protocol; drive the final round (three empty prior-round message
-    // maps) so the timed `advance` performs the presign output construction rather than the
-    // round-simulation bookkeeping of an intermediate round.
+    // ECDSA presign is a 4-round protocol; drive the final round (three prior rounds of
+    // all-honest message maps — the mock advance enforces the threshold over the latest
+    // round's honest senders) so the timed `advance` performs the presign output
+    // construction rather than the round-simulation bookkeeping of an intermediate round.
+    let honest_round: HashMap<PartyID, u64> = (1..=4)
+        .map(|party_id| (party_id as PartyID, crate::mock::MOCK_HONEST_MESSAGE))
+        .collect();
     report(
         "ECDSA presign (secp256k1): full party advance (finalize final round)",
         200,
@@ -165,7 +169,11 @@ fn mock_protocol_timings_report() {
                 session_id,
                 1 as PartyID,
                 &access_structure,
-                vec![HashMap::new(), HashMap::new(), HashMap::new()],
+                vec![
+                    honest_round.clone(),
+                    honest_round.clone(),
+                    honest_round.clone(),
+                ],
                 Some(()),
                 &presign_public_input,
                 &mut OsCsRng,

--- a/2pc-mpc/src/mock/vss.rs
+++ b/2pc-mpc/src/mock/vss.rs
@@ -271,7 +271,7 @@ where
         Self::Error,
     > {
         // Schnorr-VSS presign decentralized party is a 3-round protocol.
-        crate::mock::mock_advance_result(&messages, 3, || {
+        crate::mock::mock_advance_result(access_structure, &messages, 3, || {
             let protocol_public_parameters = &*public_input.protocol_public_parameters;
             let identity_point = GroupElement::neutral_from_public_parameters(
                 &protocol_public_parameters.group_public_parameters,
@@ -569,7 +569,7 @@ where
     fn advance(
         _session_id: CommitmentSizedNumber,
         _party_id: PartyID,
-        _access_structure: &WeightedThresholdAccessStructure,
+        access_structure: &WeightedThresholdAccessStructure,
         messages: Vec<HashMap<PartyID, Self::Message>>,
         _private_input: Option<Self::PrivateInput>,
         public_input: &Self::PublicInput,
@@ -579,7 +579,7 @@ where
         Self::Error,
     > {
         // Schnorr-VSS sign decentralized party is a 2-round protocol (happy-flow).
-        crate::mock::mock_advance_result(&messages, 2, || {
+        crate::mock::mock_advance_result(access_structure, &messages, 2, || {
             let protocol_public_parameters = &*public_input.protocol_public_parameters;
             let signature = mock_sign::<SCALAR_LIMBS, GroupElement>(
                 &public_input.message,
@@ -871,7 +871,7 @@ where
     fn advance(
         _session_id: CommitmentSizedNumber,
         _party_id: PartyID,
-        _access_structure: &WeightedThresholdAccessStructure,
+        access_structure: &WeightedThresholdAccessStructure,
         messages: Vec<HashMap<PartyID, Self::Message>>,
         _private_input: Option<Self::PrivateInput>,
         public_input: &Self::PublicInput,
@@ -882,7 +882,7 @@ where
     > {
         // The fused Schnorr-VSS DKG+sign decentralized party shares the sign protocol's 2-round
         // (happy-flow) structure.
-        crate::mock::mock_advance_result(&messages, 2, || {
+        crate::mock::mock_advance_result(access_structure, &messages, 2, || {
             let protocol_public_parameters = &*public_input.protocol_public_parameters;
             let dkg_output = crate::mock::dkg::mock_dkg_output::<SCALAR_LIMBS, GroupElement, _, _>(
                 protocol_public_parameters,


### PR DESCRIPTION
Two `unsafe_mock` faithfulness fixes surfaced by the ika dwallet-mpc integration tests (dwallet-labs/ika#1802) running under the mocks:

## 1. Schnorr-AHE mock presign: pp-derived global-output commitment

The mock presign hardcoded `global_decentralized_party_output_commitment = CommitmentSizedNumber::ZERO`. The Schnorr-AHE `Presign` is unversioned, so `Presign == pp` always compares this field, and the **real** centralized sign party — which the mock protocols deliberately keep — rejected every mock presign with `InvalidParameters` (ika: `sign_flow_test` / `future_sign_flow_test` over EdDSA). Derive the commitment from the protocol public parameters, exactly as the mock DKG output already does. ECDSA is unaffected: its mock emits the `TargetedPresign` variant, whose comparison skips the commitment.

## 2. `mock_advance_result`: enforce the threshold like the real protocols

A real protocol's `advance` first filters protocol-invalid contributions and then requires the remaining senders to form an authorized subset, aborting with `ErrorKind::ThresholdNotReached` otherwise — which the guaranteed-output-delivery layer converts into a `ThresholdNotReached` message plus a retried advance. The mock ignored the access structure entirely, so a corrupted-but-transport-valid message could never produce the TNR choreography downstream tests exercise (ika: `test_threshold_not_reached_n_times_flow_succeeds`). `mock_advance_result` now takes the access structure and runs `is_authorized_subset` over the latest completed round's honest senders; the error round-trips losslessly through `twopc_mpc::ErrorKind::MPC`.

The timings drive now sends all-honest prior rounds (empty message maps trip the new threshold check).

Verified with `cargo test --release -p twopc_mpc --features unsafe_mock mock`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)