### PR TITLE
feat(2pc-mpc): aggregated DKG/Reconfiguration public outputs

### DIFF
--- a/2pc-mpc/src/decentralized_party.rs
+++ b/2pc-mpc/src/decentralized_party.rs
@@ -633,6 +633,32 @@ mod tests {
                 })
                 .collect();
 
+        // Same equivalence for the reconfiguration output's aggregated form.
+        let aggregated_epoch1_self_reconfiguration_output = epoch1_self_reconfiguration_output
+            .clone()
+            .upgrade()
+            .expect("upgrading the reconfiguration public output should succeed");
+        for (&party_id, expected_shares) in &epoch1_secp256k1_secret_key_shares {
+            let aggregated_shares = aggregated_epoch1_self_reconfiguration_output
+                .compute_secp256k1_shamir_shares_of_secret_key_share_parts(
+                    party_id,
+                    *epoch1_secp256k1_pvss_decryption_keys
+                        .get(&party_id)
+                        .unwrap(),
+                    epoch1_secp256k1_pvss_encryption_keys_and_proofs
+                        .get(&party_id)
+                        .unwrap()
+                        .0,
+                )
+                .expect(
+                    "compute secp256k1 shamir shares from the aggregated output should succeed",
+                );
+            assert_eq!(
+                aggregated_shares, *expected_shares,
+                "aggregated-output secp256k1 share computation must match the pre-aggregation output"
+            );
+        }
+
         let (
             epoch1_secp256k1_first_polynomial_commitments,
             epoch1_secp256k1_second_polynomial_commitments,
@@ -895,7 +921,10 @@ mod tests {
         let reconstructed_dkg_output =
             crate::decentralized_party::dkg::PublicOutput::new_from_reconfiguration_output(
                 universal_class_group_dkg_output.clone(),
-                reconfiguration_public_output.clone(),
+                reconfiguration_public_output
+                    .clone()
+                    .upgrade()
+                    .expect("upgrading the reconfiguration output must succeed"),
             )
             .unwrap();
         assert_eq!(

--- a/2pc-mpc/src/decentralized_party/dkg.rs
+++ b/2pc-mpc/src/decentralized_party/dkg.rs
@@ -41,7 +41,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 
 use crate::BaseProtocolContext;
-pub use public_output::{PublicOutput, PublicOutputCore};
+pub use public_output::{NonAggregatedPublicOutput, PublicOutput, PublicOutputCore};
 
 #[cfg(not(feature = "unsafe_mock"))]
 pub struct Party {}

--- a/2pc-mpc/src/decentralized_party/dkg/public_output.rs
+++ b/2pc-mpc/src/decentralized_party/dkg/public_output.rs
@@ -35,7 +35,7 @@ use crate::decentralized_party::reconfiguration;
 use crate::Result;
 
 /// The DKG public output without the Shamir sharing of the secret key share parts. This is
-/// also the `PublicOutput` of the backward-compatible DKG protocol — both protocols share
+/// also the `NonAggregatedPublicOutput` of the backward-compatible DKG protocol — both protocols share
 /// one struct, one implementation, and one BCS encoding for the common prefix.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct PublicOutputCore {
@@ -88,17 +88,24 @@ pub struct PublicOutputCore {
             NUM_ENCRYPTION_OF_DECRYPTION_KEY_PRIMES],
 }
 
-/// The Public Output of the DKG protocol.
+/// BACKWARD COMPATIBILITY ONLY — the DKG public output in the pre-aggregation
+/// shape (every dealer's full PVSS dealing). The DKG protocol now produces the
+/// primary (aggregated) [`PublicOutput`] directly; this type exists solely to
+/// keep previously-persisted pre-aggregation bytes decodable (e.g. testnet
+/// validators' reconstructed anchors) and to reconstruct byte-identical
+/// pre-aggregation anchors from a pre-aggregation reconfiguration output
+/// during the gated rollout. Do not use for new consumers; `upgrade()` to
+/// [`PublicOutput`] instead.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
-pub struct PublicOutput {
+pub struct NonAggregatedPublicOutput {
     pub core: PublicOutputCore,
 
     /// Protocol 0.1 output: threshold encryption to sharing (Shamir shares data).
     pub(crate) threshold_encryption_to_sharing_output:
-        crate::decentralized_party::threshold_encryption_of_secret_key_share_parts_to_sharing::PublicOutput,
+        crate::decentralized_party::threshold_encryption_of_secret_key_share_parts_to_sharing::NonAggregatedPublicOutput,
 }
 
-impl std::ops::Deref for PublicOutput {
+impl std::ops::Deref for NonAggregatedPublicOutput {
     type Target = PublicOutputCore;
     fn deref(&self) -> &Self::Target {
         &self.core
@@ -578,7 +585,7 @@ impl PublicOutputCore {
     /// This is the underlying `class_groups::dkg::PublicOutput` — a single object shared by all
     /// curves — holding the encryption key $\textsf{pk}$, the per-CRT-prime threshold encryption
     /// keys, the public verification keys and the per-CRT-prime encryptions of the shares. It is
-    /// the inverse of [`PublicOutput::new_from_reconfiguration_output`].
+    /// the inverse of [`NonAggregatedPublicOutput::new_from_reconfiguration_output`].
     pub fn class_group_dkg_output(
         &self,
     ) -> ::class_groups::dkg::PublicOutput<
@@ -634,7 +641,7 @@ impl PublicOutputCore {
     }
 }
 
-impl PublicOutput {
+impl NonAggregatedPublicOutput {
     /// Reconstructs the decentralized party DKG output from a class-group DKG output and a
     /// reconfiguration output.
     ///
@@ -653,7 +660,7 @@ impl PublicOutput {
             FUNDAMENTAL_DISCRIMINANT_LIMBS,
             NON_FUNDAMENTAL_DISCRIMINANT_LIMBS,
         >,
-        reconfiguration_output: reconfiguration::PublicOutput,
+        reconfiguration_output: reconfiguration::NonAggregatedPublicOutput,
     ) -> Result<Self> {
         // Borrow-then-move: read the values held behind private getters first (they copy/clone),
         // then move the by-value per-curve fields out of the owned reconfiguration output.
@@ -985,14 +992,387 @@ impl From<PublicOutputCore>
     }
 }
 
-impl From<PublicOutput>
+impl From<NonAggregatedPublicOutput>
     for ::class_groups::dkg::PublicOutput<
         SCALAR_LIMBS,
         FUNDAMENTAL_DISCRIMINANT_LIMBS,
         NON_FUNDAMENTAL_DISCRIMINANT_LIMBS,
     >
 {
-    fn from(public_output: PublicOutput) -> Self {
+    fn from(public_output: NonAggregatedPublicOutput) -> Self {
         public_output.core.into()
+    }
+}
+
+/// The DKG public output in the aggregated form: the same [`PublicOutputCore`] plus the
+/// aggregated threshold-encryption-to-sharing output (one summed randomizer-share ciphertext
+/// per receiver instead of every dealer's full PVSS dealing — see
+/// [`crate::decentralized_party::threshold_encryption_of_secret_key_share_parts_to_sharing::aggregated_public_output`]).
+///
+/// This is the DKG protocol's output: the per-receiver aggregation happens at
+/// output formation (seventh round). [`NonAggregatedPublicOutput`] exists only
+/// for backward compatibility.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+pub struct PublicOutput {
+    pub core: PublicOutputCore,
+
+    /// Protocol 0.1 output in aggregated form (Shamir shares data, one ciphertext per receiver).
+    pub(crate) threshold_encryption_to_sharing_output:
+        crate::decentralized_party::threshold_encryption_of_secret_key_share_parts_to_sharing::aggregated_public_output::PublicOutput,
+}
+
+impl std::ops::Deref for PublicOutput {
+    type Target = PublicOutputCore;
+    fn deref(&self) -> &Self::Target {
+        &self.core
+    }
+}
+
+impl NonAggregatedPublicOutput {
+    /// Upgrades to the aggregated [`PublicOutput`] by homomorphically aggregating,
+    /// per receiving party, the encrypted randomizer shares across the persisted dealings.
+    pub fn upgrade(self) -> Result<PublicOutput> {
+        Ok(PublicOutput {
+            core: self.core,
+            threshold_encryption_to_sharing_output: self
+                .threshold_encryption_to_sharing_output
+                .upgrade()?,
+        })
+    }
+}
+
+impl PublicOutput {
+    /// Reconstructs the decentralized party DKG output from a class-group DKG output and a
+    /// reconfiguration output.
+    ///
+    /// The reconfiguration output carries the post-reconfiguration per-curve data (public key
+    /// shares, encryptions of the secret key share parts, the per-curve encryption keys and the
+    /// upcoming committee's public verification keys), while the class-group DKG output supplies
+    /// the reconfiguration-invariant per-CRT-prime data (`threshold_encryption_key_per_crt_prime`,
+    /// `encryptions_of_shares_per_crt_prime` and `threshold_encryption_of_decryption_key_per_crt_prime`)
+    /// that the reconfiguration output does not retain. Together they form a full decentralized
+    /// party DKG output for the upcoming committee.
+    ///
+    /// This is the inverse of [`PublicOutputCore::class_group_dkg_output`], for the aggregated
+    /// output form.
+    pub fn new_from_reconfiguration_output(
+        class_group_dkg_output: ::class_groups::dkg::PublicOutput<
+            SCALAR_LIMBS,
+            FUNDAMENTAL_DISCRIMINANT_LIMBS,
+            NON_FUNDAMENTAL_DISCRIMINANT_LIMBS,
+        >,
+        reconfiguration_output: reconfiguration::PublicOutput,
+    ) -> Result<Self> {
+        // Borrow-then-move: read the values held behind private getters first (they copy/clone),
+        // then move the by-value per-curve fields out of the owned reconfiguration output.
+        let ristretto_encryption_key = reconfiguration_output.ristretto_encryption_key();
+        let ristretto_public_verification_keys =
+            reconfiguration_output.ristretto_public_verification_keys();
+        let secp256r1_encryption_key = reconfiguration_output.secp256r1_encryption_key();
+        let secp256r1_public_verification_keys =
+            reconfiguration_output.secp256r1_public_verification_keys();
+
+        let core = PublicOutputCore::new(
+            class_group_dkg_output,
+            reconfiguration_output
+                .core
+                .secp256k1_encryption_of_secret_key_share_first_part,
+            reconfiguration_output
+                .core
+                .secp256k1_encryption_of_secret_key_share_second_part,
+            reconfiguration_output
+                .core
+                .secp256k1_public_key_share_first_part,
+            reconfiguration_output
+                .core
+                .secp256k1_public_key_share_second_part,
+            reconfiguration_output
+                .core
+                .ristretto_encryption_of_secret_key_share_first_part,
+            reconfiguration_output
+                .core
+                .ristretto_encryption_of_secret_key_share_second_part,
+            reconfiguration_output
+                .core
+                .ristretto_public_key_share_first_part,
+            reconfiguration_output
+                .core
+                .ristretto_public_key_share_second_part,
+            ristretto_encryption_key,
+            ristretto_public_verification_keys,
+            reconfiguration_output
+                .core
+                .curve25519_encryption_of_secret_key_share_first_part,
+            reconfiguration_output
+                .core
+                .curve25519_encryption_of_secret_key_share_second_part,
+            reconfiguration_output
+                .core
+                .curve25519_public_key_share_first_part,
+            reconfiguration_output
+                .core
+                .curve25519_public_key_share_second_part,
+            reconfiguration_output
+                .core
+                .secp256r1_encryption_of_secret_key_share_first_part,
+            reconfiguration_output
+                .core
+                .secp256r1_encryption_of_secret_key_share_second_part,
+            reconfiguration_output
+                .core
+                .secp256r1_public_key_share_first_part,
+            reconfiguration_output
+                .core
+                .secp256r1_public_key_share_second_part,
+            secp256r1_encryption_key,
+            secp256r1_public_verification_keys,
+        )?;
+
+        Ok(Self {
+            core,
+            threshold_encryption_to_sharing_output: reconfiguration_output
+                .threshold_encryption_to_sharing_output,
+        })
+    }
+
+    /// Derives the Shamir shares of secp256k1 secret key share parts from the DKG output.
+    ///
+    /// This method computes the shares `([x_0]_i, [x_1]_i)` from the threshold encryption
+    /// scheme, using the party's PVSS decryption key to decrypt their shares of the randomizers.
+    pub fn derive_shamir_shares_of_secp256k1_secret_key_share_parts(
+        &self,
+        party_id: PartyID,
+        pvss_decryption_key: crypto_bigint::Uint<FUNDAMENTAL_DISCRIMINANT_LIMBS>,
+        pvss_encryption_key: CompactIbqf<NON_FUNDAMENTAL_DISCRIMINANT_LIMBS>,
+    ) -> Result<(
+        group::Value<secp256k1::Scalar>,
+        group::Value<secp256k1::Scalar>,
+    )> {
+        let setup_parameters =
+            Secp256k1SetupParameters::derive_from_plaintext_parameters::<secp256k1::Scalar>(
+                secp256k1::scalar::PublicParameters::default(),
+                DEFAULT_COMPUTATIONAL_SECURITY_PARAMETER,
+            )?;
+
+        let pvss_encryption_key = EquivalenceClass::new(
+            pvss_encryption_key,
+            setup_parameters.equivalence_class_public_parameters(),
+        )?;
+
+        let encryption_scheme_public_parameters =
+            encryption_key::PublicParameters::new(setup_parameters, pvss_encryption_key)?;
+
+        crate::decentralized_party::threshold_encryption_of_secret_key_share_parts_to_sharing::aggregated_public_output::derive_shamir_shares_of_secret_key_share_parts_from_aggregated_encryptions::<
+            { secp256k1::SCALAR_LIMBS },
+            { class_groups::SECP256K1_FUNDAMENTAL_DISCRIMINANT_LIMBS },
+            { class_groups::SECP256K1_NON_FUNDAMENTAL_DISCRIMINANT_LIMBS },
+            secp256k1::GroupElement,
+        >(
+            party_id,
+            &encryption_scheme_public_parameters,
+            pvss_decryption_key,
+            &self.threshold_encryption_to_sharing_output.secp256k1_first_encryptions_of_randomizer_shares,
+            &self.threshold_encryption_to_sharing_output.secp256k1_second_encryptions_of_randomizer_shares,
+            self.threshold_encryption_to_sharing_output.secp256k1_first_masked_secret_key_share_part,
+            self.threshold_encryption_to_sharing_output.secp256k1_second_masked_secret_key_share_part,
+        )
+    }
+
+    /// Derives the Shamir shares of ristretto secret key share parts from the DKG output.
+    ///
+    /// This method computes the shares `([x_0]_i, [x_1]_i)` from the threshold encryption
+    /// scheme, using the party's PVSS decryption key to decrypt their shares of the randomizers.
+    pub fn derive_shamir_shares_of_ristretto_secret_key_share_parts(
+        &self,
+        party_id: PartyID,
+        pvss_decryption_key: crypto_bigint::Uint<FUNDAMENTAL_DISCRIMINANT_LIMBS>,
+        pvss_encryption_key: CompactIbqf<NON_FUNDAMENTAL_DISCRIMINANT_LIMBS>,
+    ) -> Result<(
+        group::Value<ristretto::Scalar>,
+        group::Value<ristretto::Scalar>,
+    )> {
+        let setup_parameters =
+            RistrettoSetupParameters::derive_from_plaintext_parameters::<ristretto::Scalar>(
+                ristretto::scalar::PublicParameters::default(),
+                DEFAULT_COMPUTATIONAL_SECURITY_PARAMETER,
+            )?;
+
+        let pvss_encryption_key = EquivalenceClass::new(
+            pvss_encryption_key,
+            setup_parameters.equivalence_class_public_parameters(),
+        )?;
+
+        let encryption_scheme_public_parameters =
+            encryption_key::PublicParameters::new(setup_parameters, pvss_encryption_key)?;
+
+        crate::decentralized_party::threshold_encryption_of_secret_key_share_parts_to_sharing::aggregated_public_output::derive_shamir_shares_of_secret_key_share_parts_from_aggregated_encryptions::<
+            { ristretto::SCALAR_LIMBS },
+            { class_groups::RISTRETTO_FUNDAMENTAL_DISCRIMINANT_LIMBS },
+            { class_groups::RISTRETTO_NON_FUNDAMENTAL_DISCRIMINANT_LIMBS },
+            ristretto::GroupElement,
+        >(
+            party_id,
+            &encryption_scheme_public_parameters,
+            pvss_decryption_key,
+            &self.threshold_encryption_to_sharing_output.ristretto_first_encryptions_of_randomizer_shares,
+            &self.threshold_encryption_to_sharing_output.ristretto_second_encryptions_of_randomizer_shares,
+            self.threshold_encryption_to_sharing_output.ristretto_first_masked_secret_key_share_part,
+            self.threshold_encryption_to_sharing_output.ristretto_second_masked_secret_key_share_part,
+        )
+    }
+
+    /// Derives the Shamir shares of curve25519 secret key share parts from the DKG output.
+    ///
+    /// This method computes the shares `([x_0]_i, [x_1]_i)` from the threshold encryption
+    /// scheme, using the party's PVSS decryption key to decrypt their shares of the randomizers.
+    /// Note: curve25519 uses ristretto decryption keys since they share the same scalar field.
+    pub fn derive_shamir_shares_of_curve25519_secret_key_share_parts(
+        &self,
+        party_id: PartyID,
+        pvss_decryption_key: crypto_bigint::Uint<FUNDAMENTAL_DISCRIMINANT_LIMBS>,
+        pvss_encryption_key: CompactIbqf<NON_FUNDAMENTAL_DISCRIMINANT_LIMBS>,
+    ) -> Result<(
+        group::Value<curve25519::Scalar>,
+        group::Value<curve25519::Scalar>,
+    )> {
+        let setup_parameters =
+            Curve25519SetupParameters::derive_from_plaintext_parameters::<curve25519::Scalar>(
+                curve25519::scalar::PublicParameters::default(),
+                DEFAULT_COMPUTATIONAL_SECURITY_PARAMETER,
+            )?;
+
+        let pvss_encryption_key = EquivalenceClass::new(
+            pvss_encryption_key,
+            setup_parameters.equivalence_class_public_parameters(),
+        )?;
+
+        let encryption_scheme_public_parameters =
+            encryption_key::PublicParameters::new(setup_parameters, pvss_encryption_key)?;
+
+        crate::decentralized_party::threshold_encryption_of_secret_key_share_parts_to_sharing::aggregated_public_output::derive_shamir_shares_of_secret_key_share_parts_from_aggregated_encryptions::<
+            { curve25519::SCALAR_LIMBS },
+            { class_groups::RISTRETTO_FUNDAMENTAL_DISCRIMINANT_LIMBS },
+            { class_groups::RISTRETTO_NON_FUNDAMENTAL_DISCRIMINANT_LIMBS },
+            curve25519::GroupElement,
+        >(
+            party_id,
+            &encryption_scheme_public_parameters,
+            pvss_decryption_key,
+            &self.threshold_encryption_to_sharing_output.curve25519_first_encryptions_of_randomizer_shares,
+            &self.threshold_encryption_to_sharing_output.curve25519_second_encryptions_of_randomizer_shares,
+            self.threshold_encryption_to_sharing_output.curve25519_first_masked_secret_key_share_part,
+            self.threshold_encryption_to_sharing_output.curve25519_second_masked_secret_key_share_part,
+        )
+    }
+
+    /// Derives the Shamir shares of secp256r1 secret key share parts from the DKG output.
+    ///
+    /// This method computes the shares `([x_0]_i, [x_1]_i)` from the threshold encryption
+    /// scheme, using the party's PVSS decryption key to decrypt their shares of the randomizers.
+    pub fn derive_shamir_shares_of_secp256r1_secret_key_share_parts(
+        &self,
+        party_id: PartyID,
+        pvss_decryption_key: crypto_bigint::Uint<FUNDAMENTAL_DISCRIMINANT_LIMBS>,
+        pvss_encryption_key: CompactIbqf<NON_FUNDAMENTAL_DISCRIMINANT_LIMBS>,
+    ) -> Result<(
+        group::Value<secp256r1::Scalar>,
+        group::Value<secp256r1::Scalar>,
+    )> {
+        let setup_parameters =
+            Secp256r1SetupParameters::derive_from_plaintext_parameters::<secp256r1::Scalar>(
+                secp256r1::scalar::PublicParameters::default(),
+                DEFAULT_COMPUTATIONAL_SECURITY_PARAMETER,
+            )?;
+
+        let pvss_encryption_key = EquivalenceClass::new(
+            pvss_encryption_key,
+            setup_parameters.equivalence_class_public_parameters(),
+        )?;
+
+        let encryption_scheme_public_parameters =
+            encryption_key::PublicParameters::new(setup_parameters, pvss_encryption_key)?;
+
+        crate::decentralized_party::threshold_encryption_of_secret_key_share_parts_to_sharing::aggregated_public_output::derive_shamir_shares_of_secret_key_share_parts_from_aggregated_encryptions::<
+            { secp256r1::SCALAR_LIMBS },
+            { class_groups::SECP256R1_FUNDAMENTAL_DISCRIMINANT_LIMBS },
+            { class_groups::SECP256R1_NON_FUNDAMENTAL_DISCRIMINANT_LIMBS },
+            secp256r1::GroupElement,
+        >(
+            party_id,
+            &encryption_scheme_public_parameters,
+            pvss_decryption_key,
+            &self.threshold_encryption_to_sharing_output.secp256r1_first_encryptions_of_randomizer_shares,
+            &self.threshold_encryption_to_sharing_output.secp256r1_second_encryptions_of_randomizer_shares,
+            self.threshold_encryption_to_sharing_output.secp256r1_first_masked_secret_key_share_part,
+            self.threshold_encryption_to_sharing_output.secp256r1_second_masked_secret_key_share_part,
+        )
+    }
+
+    /// Returns the polynomial commitments for secp256k1.
+    pub fn secp256k1_polynomial_commitments(
+        &self,
+    ) -> (
+        &Vec<secp256k1::group_element::Value>,
+        &Vec<secp256k1::group_element::Value>,
+    ) {
+        (
+            &self
+                .threshold_encryption_to_sharing_output
+                .secp256k1_first_secret_polynomial_commitments,
+            &self
+                .threshold_encryption_to_sharing_output
+                .secp256k1_second_secret_polynomial_commitments,
+        )
+    }
+
+    /// Returns the polynomial commitments for ristretto.
+    pub fn ristretto_polynomial_commitments(
+        &self,
+    ) -> (
+        &Vec<group::Value<ristretto::GroupElement>>,
+        &Vec<group::Value<ristretto::GroupElement>>,
+    ) {
+        (
+            &self
+                .threshold_encryption_to_sharing_output
+                .ristretto_first_secret_polynomial_commitments,
+            &self
+                .threshold_encryption_to_sharing_output
+                .ristretto_second_secret_polynomial_commitments,
+        )
+    }
+
+    /// Returns the polynomial commitments for curve25519.
+    pub fn curve25519_polynomial_commitments(
+        &self,
+    ) -> (
+        &Vec<group::Value<curve25519::GroupElement>>,
+        &Vec<group::Value<curve25519::GroupElement>>,
+    ) {
+        (
+            &self
+                .threshold_encryption_to_sharing_output
+                .curve25519_first_secret_polynomial_commitments,
+            &self
+                .threshold_encryption_to_sharing_output
+                .curve25519_second_secret_polynomial_commitments,
+        )
+    }
+
+    /// Returns the polynomial commitments for secp256r1.
+    pub fn secp256r1_polynomial_commitments(
+        &self,
+    ) -> (
+        &Vec<secp256r1::group_element::Value>,
+        &Vec<secp256r1::group_element::Value>,
+    ) {
+        (
+            &self
+                .threshold_encryption_to_sharing_output
+                .secp256r1_first_secret_polynomial_commitments,
+            &self
+                .threshold_encryption_to_sharing_output
+                .secp256r1_second_secret_polynomial_commitments,
+        )
     }
 }

--- a/2pc-mpc/src/decentralized_party/dkg/seventh_round.rs
+++ b/2pc-mpc/src/decentralized_party/dkg/seventh_round.rs
@@ -84,9 +84,14 @@ impl super::Party {
             fourth_round_output.secp256r1_public_verification_keys,
         )?;
 
+        // The DKG's output is the primary (aggregated) form: unlike
+        // reconfiguration — whose wire output must stay byte-identical to
+        // deployed binaries through the gated rollout — no deployed network
+        // ever persisted a pre-aggregation DKG output, so the per-receiver
+        // aggregation happens right here at output formation.
         let public_output = PublicOutput {
             core,
-            threshold_encryption_to_sharing_output: threshold_enc_public_output,
+            threshold_encryption_to_sharing_output: threshold_enc_public_output.upgrade()?,
         };
 
         Ok(AsynchronousRoundResult::Finalize {

--- a/2pc-mpc/src/decentralized_party/reconfiguration.rs
+++ b/2pc-mpc/src/decentralized_party/reconfiguration.rs
@@ -36,7 +36,7 @@ use group::{
     GroupElement as _, PartyID,
 };
 use mpc::{AsynchronousRoundResult, AsynchronouslyAdvanceable, WeightedThresholdAccessStructure};
-pub use public_output::{PublicOutput, PublicOutputCore};
+pub use public_output::{NonAggregatedPublicOutput, PublicOutput, PublicOutputCore};
 
 #[cfg(feature = "unsafe_mock")]
 pub use crate::mock::network_dkg::MockNetworkReconfigurationParty as Party;
@@ -836,7 +836,11 @@ impl mpc::Party for Party {
     type Error = Error;
     type PublicInput = PublicInput;
     type PrivateOutput = ();
-    type PublicOutputValue = PublicOutput;
+    // The Party's wire output stays the NON-aggregated shape: it is the deployed
+    // v4 quorum format the gated reconfiguration rollout must keep emitting
+    // byte-identically. Consumers upgrade() to the primary (aggregated)
+    // `PublicOutput` on demand.
+    type PublicOutputValue = NonAggregatedPublicOutput;
     type PublicOutput = Self::PublicOutputValue;
     type Message = Message;
 }
@@ -1102,7 +1106,7 @@ pub(crate) mod tests {
         current_tangible_party_id_to_upcoming: HashMap<PartyID, Option<PartyID>>,
         backward_compatible: bool,
         bench: bool,
-    ) -> PublicOutput {
+    ) -> NonAggregatedPublicOutput {
         let secp256k1_setup_parameters = get_setup_parameters_secp256k1_112_bits_deterministic();
         let (secp256k1_encryption_scheme_public_parameters, secp256k1_decryption_key) =
             Secp256k1DecryptionKey::generate_with_setup_parameters(
@@ -1517,7 +1521,7 @@ pub(crate) mod tests {
         private_inputs: HashMap<PartyID, HashMap<PartyID, SecretKeyShareSizedInteger>>,
         public_input: PublicInput,
         bench: bool,
-    ) -> PublicOutput {
+    ) -> NonAggregatedPublicOutput {
         let public_inputs = current_access_structure
             .party_to_weight
             .keys()

--- a/2pc-mpc/src/decentralized_party/reconfiguration/first_round.rs
+++ b/2pc-mpc/src/decentralized_party/reconfiguration/first_round.rs
@@ -5,7 +5,7 @@ use itertools::multiunzip;
 
 use super::{EqualityOfCoefficientsCommitmentsProof, PublicInput};
 use crate::decentralized_party::reconfiguration::Message;
-use crate::decentralized_party::reconfiguration::PublicOutput;
+use crate::decentralized_party::reconfiguration::NonAggregatedPublicOutput;
 use crate::languages::EqualityOfDiscreteLogsInHiddenOrderGroupPublicParameters;
 use crate::{decentralized_party::dkg, Error, ErrorKind, Result};
 use class_groups::publicly_verifiable_secret_sharing::chinese_remainder_theorem::NUM_SECRET_SHARE_PRIMES;
@@ -50,7 +50,7 @@ impl super::Party {
         equality_of_coefficients_commitments_base_protocol_context: crate::BaseProtocolContext,
         randomizer_contribution_bits: u32,
         rng: &mut impl CsRng,
-    ) -> Result<AsynchronousRoundResult<Message, (), PublicOutput>> {
+    ) -> Result<AsynchronousRoundResult<Message, (), NonAggregatedPublicOutput>> {
         Self::advance_first_round_internal(
             tangible_party_id,
             session_id,

--- a/2pc-mpc/src/decentralized_party/reconfiguration/fourth_round.rs
+++ b/2pc-mpc/src/decentralized_party/reconfiguration/fourth_round.rs
@@ -3,7 +3,9 @@
 
 use super::PublicInput;
 
-use crate::decentralized_party::reconfiguration::{Message, PublicOutput, PublicOutputCore};
+use crate::decentralized_party::reconfiguration::{
+    Message, NonAggregatedPublicOutput, PublicOutputCore,
+};
 use crate::decentralized_party::threshold_encryption_of_secret_key_share_parts_to_sharing::{
     self, DealingRoundMessage, ThresholdDecryptionRoundMessage,
 };
@@ -45,7 +47,7 @@ impl super::Party {
         threshold_decrypt_messages: HashMap<PartyID, Message>,
         current_decryption_key_share_bits: u32,
         rng: &mut impl CsRng,
-    ) -> Result<AsynchronousRoundResult<Message, (), PublicOutput>> {
+    ) -> Result<AsynchronousRoundResult<Message, (), NonAggregatedPublicOutput>> {
         let (
             malicious_parties,
             inner_protocol_public_output,
@@ -87,7 +89,7 @@ impl super::Party {
             rng,
         )?;
 
-        // Step 5: Construct PublicOutput with the threshold_encryption_to_sharing_output
+        // Step 5: Construct NonAggregatedPublicOutput with the threshold_encryption_to_sharing_output
         let core = PublicOutputCore::new(
             inner_protocol_public_output,
             public_input.secp256k1_encryption_of_secret_key_share_first_part,
@@ -121,7 +123,7 @@ impl super::Party {
                 .equivalence_class_public_parameters(),
         )?;
 
-        let public_output = PublicOutput {
+        let public_output = NonAggregatedPublicOutput {
             core,
             threshold_encryption_to_sharing_output:
                 threshold_encryption_of_secret_key_share_parts_to_sharing_public_output,

--- a/2pc-mpc/src/decentralized_party/reconfiguration/public_output.rs
+++ b/2pc-mpc/src/decentralized_party/reconfiguration/public_output.rs
@@ -30,7 +30,7 @@ use mpc::WeightedThresholdAccessStructure;
 use crate::{decentralized_party::dkg, Result};
 
 /// The Reconfiguration public output without the Shamir sharing of the secret key share
-/// parts. This is also the `PublicOutput` of the backward-compatible Reconfiguration
+/// parts. This is also the `NonAggregatedPublicOutput` of the backward-compatible Reconfiguration
 /// protocol — both protocols share one struct, one implementation, and one BCS encoding
 /// for the common prefix.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
@@ -79,18 +79,26 @@ pub struct PublicOutputCore {
     >,
 }
 
-/// The Public Output of the Reconfiguration protocol.
+/// BACKWARD COMPATIBILITY ONLY — the Reconfiguration public output in the
+/// pre-aggregation shape (every dealer's full PVSS dealing). This is still the
+/// Party's wire output because it is the deployed format: consumers on the
+/// live network must keep reaching byte-identical output quorum across a
+/// mixed-binary committee, so the reconfiguration protocol keeps emitting
+/// these bytes until the consumer-side protocol gate flips. Every consumer
+/// should `upgrade()` to the primary (aggregated) [`PublicOutput`]; once the
+/// deployed network is fully past the gate, the Party output moves to
+/// [`PublicOutput`] and this type retires to decode-only.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
-pub struct PublicOutput {
+pub struct NonAggregatedPublicOutput {
     pub core: PublicOutputCore,
 
     // Protocol 0.1 output: threshold encryption to sharing subprotocol output.
     // This contains the randomizer dealings, masked secrets, and polynomial commitments.
     pub(crate) threshold_encryption_to_sharing_output:
-        crate::decentralized_party::threshold_encryption_of_secret_key_share_parts_to_sharing::PublicOutput,
+        crate::decentralized_party::threshold_encryption_of_secret_key_share_parts_to_sharing::NonAggregatedPublicOutput,
 }
 
-impl std::ops::Deref for PublicOutput {
+impl std::ops::Deref for NonAggregatedPublicOutput {
     type Target = PublicOutputCore;
     fn deref(&self) -> &Self::Target {
         &self.core
@@ -598,7 +606,7 @@ impl PublicOutputCore {
     }
 }
 
-impl PublicOutput {
+impl NonAggregatedPublicOutput {
     /// Computes secp256k1 Shamir shares of secret key share parts for a party.
     ///
     /// Returns the Shamir shares `([x_0]_i, [x_1]_i)` computed as `(x + r) - [r]_i`.
@@ -883,6 +891,292 @@ impl PublicOutput {
                 .curve25519_first_masked_secret_key_share_part,
             self.threshold_encryption_to_sharing_output
                 .curve25519_second_masked_secret_key_share_part,
+        )
+    }
+}
+
+/// The Reconfiguration public output in the aggregated form: the same [`PublicOutputCore`]
+/// plus the aggregated threshold-encryption-to-sharing output (one summed randomizer-share
+/// ciphertext per receiver instead of every dealer's full PVSS dealing — see
+/// [`crate::decentralized_party::threshold_encryption_of_secret_key_share_parts_to_sharing::aggregated_public_output`]).
+///
+/// The Party's wire output is still [`NonAggregatedPublicOutput`] (the
+/// deployed byte-identical-quorum format); this primary form is obtained via
+/// [`NonAggregatedPublicOutput::upgrade`] and is what all consumers persist
+/// and read.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+pub struct PublicOutput {
+    pub core: PublicOutputCore,
+
+    /// Protocol 0.1 output in aggregated form (Shamir shares data, one ciphertext per receiver).
+    pub(crate) threshold_encryption_to_sharing_output:
+        crate::decentralized_party::threshold_encryption_of_secret_key_share_parts_to_sharing::aggregated_public_output::PublicOutput,
+}
+
+impl std::ops::Deref for PublicOutput {
+    type Target = PublicOutputCore;
+    fn deref(&self) -> &Self::Target {
+        &self.core
+    }
+}
+
+impl NonAggregatedPublicOutput {
+    /// Upgrades to the aggregated [`PublicOutput`] by homomorphically aggregating,
+    /// per receiving party, the encrypted randomizer shares across the persisted dealings.
+    pub fn upgrade(self) -> Result<PublicOutput> {
+        Ok(PublicOutput {
+            core: self.core,
+            threshold_encryption_to_sharing_output: self
+                .threshold_encryption_to_sharing_output
+                .upgrade()?,
+        })
+    }
+}
+
+impl PublicOutput {
+    /// Computes secp256k1 Shamir shares of secret key share parts for a party.
+    ///
+    /// Returns the Shamir shares `([x_0]_i, [x_1]_i)` computed as `(x + r) - [r]_i`.
+    pub fn compute_secp256k1_shamir_shares_of_secret_key_share_parts(
+        &self,
+        party_id: PartyID,
+        pvss_decryption_key: crypto_bigint::Uint<
+            { class_groups::SECP256K1_FUNDAMENTAL_DISCRIMINANT_LIMBS },
+        >,
+        pvss_encryption_key: CompactIbqf<NON_FUNDAMENTAL_DISCRIMINANT_LIMBS>,
+    ) -> Result<(
+        group::Value<secp256k1::Scalar>,
+        group::Value<secp256k1::Scalar>,
+    )> {
+        let setup_parameters =
+            Secp256k1SetupParameters::derive_from_plaintext_parameters::<secp256k1::Scalar>(
+                secp256k1::scalar::PublicParameters::default(),
+                DEFAULT_COMPUTATIONAL_SECURITY_PARAMETER,
+            )?;
+
+        let pvss_encryption_key = EquivalenceClass::new(
+            pvss_encryption_key,
+            setup_parameters.equivalence_class_public_parameters(),
+        )?;
+
+        let encryption_scheme_public_parameters =
+            encryption_key::PublicParameters::new(setup_parameters, pvss_encryption_key)?;
+
+        crate::decentralized_party::threshold_encryption_of_secret_key_share_parts_to_sharing::aggregated_public_output::derive_shamir_shares_of_secret_key_share_parts_from_aggregated_encryptions::<
+            { secp256k1::SCALAR_LIMBS },
+            { class_groups::SECP256K1_FUNDAMENTAL_DISCRIMINANT_LIMBS },
+            { class_groups::SECP256K1_NON_FUNDAMENTAL_DISCRIMINANT_LIMBS },
+            secp256k1::GroupElement,
+        >(
+            party_id,
+            &encryption_scheme_public_parameters,
+            pvss_decryption_key,
+            &self.threshold_encryption_to_sharing_output.secp256k1_first_encryptions_of_randomizer_shares,
+            &self.threshold_encryption_to_sharing_output.secp256k1_second_encryptions_of_randomizer_shares,
+            self.threshold_encryption_to_sharing_output.secp256k1_first_masked_secret_key_share_part,
+            self.threshold_encryption_to_sharing_output.secp256k1_second_masked_secret_key_share_part,
+        )
+    }
+
+    /// Computes ristretto Shamir shares of secret key share parts for a party.
+    ///
+    /// Returns the Shamir shares `([x_0]_i, [x_1]_i)` computed as `(x + r) - [r]_i`.
+    pub fn compute_ristretto_shamir_shares_of_secret_key_share_parts(
+        &self,
+        party_id: PartyID,
+        pvss_decryption_key: crypto_bigint::Uint<
+            { class_groups::RISTRETTO_FUNDAMENTAL_DISCRIMINANT_LIMBS },
+        >,
+        pvss_encryption_key: CompactIbqf<NON_FUNDAMENTAL_DISCRIMINANT_LIMBS>,
+    ) -> Result<(
+        group::Value<ristretto::Scalar>,
+        group::Value<ristretto::Scalar>,
+    )> {
+        let setup_parameters =
+            RistrettoSetupParameters::derive_from_plaintext_parameters::<ristretto::Scalar>(
+                ristretto::scalar::PublicParameters::default(),
+                DEFAULT_COMPUTATIONAL_SECURITY_PARAMETER,
+            )?;
+
+        let pvss_encryption_key = EquivalenceClass::new(
+            pvss_encryption_key,
+            setup_parameters.equivalence_class_public_parameters(),
+        )?;
+
+        let encryption_scheme_public_parameters =
+            encryption_key::PublicParameters::new(setup_parameters, pvss_encryption_key)?;
+
+        crate::decentralized_party::threshold_encryption_of_secret_key_share_parts_to_sharing::aggregated_public_output::derive_shamir_shares_of_secret_key_share_parts_from_aggregated_encryptions::<
+            { ristretto::SCALAR_LIMBS },
+            { class_groups::RISTRETTO_FUNDAMENTAL_DISCRIMINANT_LIMBS },
+            { class_groups::RISTRETTO_NON_FUNDAMENTAL_DISCRIMINANT_LIMBS },
+            ristretto::GroupElement,
+        >(
+            party_id,
+            &encryption_scheme_public_parameters,
+            pvss_decryption_key,
+            &self.threshold_encryption_to_sharing_output.ristretto_first_encryptions_of_randomizer_shares,
+            &self.threshold_encryption_to_sharing_output.ristretto_second_encryptions_of_randomizer_shares,
+            self.threshold_encryption_to_sharing_output.ristretto_first_masked_secret_key_share_part,
+            self.threshold_encryption_to_sharing_output.ristretto_second_masked_secret_key_share_part,
+        )
+    }
+
+    /// Computes curve25519 Shamir shares of secret key share parts for a party.
+    ///
+    /// Returns the Shamir shares `([x_0]_i, [x_1]_i)` computed as `(x + r) - [r]_i`.
+    ///
+    /// Note: curve25519 uses ristretto encryption parameters since they share the same scalar field.
+    pub fn compute_curve25519_shamir_shares_of_secret_key_share_parts(
+        &self,
+        party_id: PartyID,
+        pvss_decryption_key: crypto_bigint::Uint<
+            { class_groups::RISTRETTO_FUNDAMENTAL_DISCRIMINANT_LIMBS },
+        >,
+        pvss_encryption_key: CompactIbqf<NON_FUNDAMENTAL_DISCRIMINANT_LIMBS>,
+    ) -> Result<(
+        group::Value<curve25519::Scalar>,
+        group::Value<curve25519::Scalar>,
+    )> {
+        let setup_parameters =
+            Curve25519SetupParameters::derive_from_plaintext_parameters::<curve25519::Scalar>(
+                curve25519::scalar::PublicParameters::default(),
+                DEFAULT_COMPUTATIONAL_SECURITY_PARAMETER,
+            )?;
+
+        let pvss_encryption_key = EquivalenceClass::new(
+            pvss_encryption_key,
+            setup_parameters.equivalence_class_public_parameters(),
+        )?;
+
+        let encryption_scheme_public_parameters =
+            encryption_key::PublicParameters::new(setup_parameters, pvss_encryption_key)?;
+
+        crate::decentralized_party::threshold_encryption_of_secret_key_share_parts_to_sharing::aggregated_public_output::derive_shamir_shares_of_secret_key_share_parts_from_aggregated_encryptions::<
+            { curve25519::SCALAR_LIMBS },
+            { class_groups::RISTRETTO_FUNDAMENTAL_DISCRIMINANT_LIMBS },
+            { class_groups::RISTRETTO_NON_FUNDAMENTAL_DISCRIMINANT_LIMBS },
+            curve25519::GroupElement,
+        >(
+            party_id,
+            &encryption_scheme_public_parameters,
+            pvss_decryption_key,
+            &self.threshold_encryption_to_sharing_output.curve25519_first_encryptions_of_randomizer_shares,
+            &self.threshold_encryption_to_sharing_output.curve25519_second_encryptions_of_randomizer_shares,
+            self.threshold_encryption_to_sharing_output.curve25519_first_masked_secret_key_share_part,
+            self.threshold_encryption_to_sharing_output.curve25519_second_masked_secret_key_share_part,
+        )
+    }
+
+    /// Computes secp256r1 Shamir shares of secret key share parts for a party.
+    ///
+    /// Returns the Shamir shares `([x_0]_i, [x_1]_i)` computed as `(x + r) - [r]_i`.
+    pub fn compute_secp256r1_shamir_shares_of_secret_key_share_parts(
+        &self,
+        party_id: PartyID,
+        pvss_decryption_key: crypto_bigint::Uint<
+            { class_groups::SECP256R1_FUNDAMENTAL_DISCRIMINANT_LIMBS },
+        >,
+        pvss_encryption_key: CompactIbqf<NON_FUNDAMENTAL_DISCRIMINANT_LIMBS>,
+    ) -> Result<(
+        group::Value<secp256r1::Scalar>,
+        group::Value<secp256r1::Scalar>,
+    )> {
+        let setup_parameters =
+            Secp256r1SetupParameters::derive_from_plaintext_parameters::<secp256r1::Scalar>(
+                secp256r1::scalar::PublicParameters::default(),
+                DEFAULT_COMPUTATIONAL_SECURITY_PARAMETER,
+            )?;
+
+        let pvss_encryption_key = EquivalenceClass::new(
+            pvss_encryption_key,
+            setup_parameters.equivalence_class_public_parameters(),
+        )?;
+
+        let encryption_scheme_public_parameters =
+            encryption_key::PublicParameters::new(setup_parameters, pvss_encryption_key)?;
+
+        crate::decentralized_party::threshold_encryption_of_secret_key_share_parts_to_sharing::aggregated_public_output::derive_shamir_shares_of_secret_key_share_parts_from_aggregated_encryptions::<
+            { secp256r1::SCALAR_LIMBS },
+            { class_groups::SECP256R1_FUNDAMENTAL_DISCRIMINANT_LIMBS },
+            { class_groups::SECP256R1_NON_FUNDAMENTAL_DISCRIMINANT_LIMBS },
+            secp256r1::GroupElement,
+        >(
+            party_id,
+            &encryption_scheme_public_parameters,
+            pvss_decryption_key,
+            &self.threshold_encryption_to_sharing_output.secp256r1_first_encryptions_of_randomizer_shares,
+            &self.threshold_encryption_to_sharing_output.secp256r1_second_encryptions_of_randomizer_shares,
+            self.threshold_encryption_to_sharing_output.secp256r1_first_masked_secret_key_share_part,
+            self.threshold_encryption_to_sharing_output.secp256r1_second_masked_secret_key_share_part,
+        )
+    }
+
+    /// Returns the polynomial commitments for secp256k1.
+    pub fn secp256k1_polynomial_commitments(
+        &self,
+    ) -> (
+        &Vec<secp256k1::group_element::Value>,
+        &Vec<secp256k1::group_element::Value>,
+    ) {
+        (
+            &self
+                .threshold_encryption_to_sharing_output
+                .secp256k1_first_secret_polynomial_commitments,
+            &self
+                .threshold_encryption_to_sharing_output
+                .secp256k1_second_secret_polynomial_commitments,
+        )
+    }
+
+    /// Returns the polynomial commitments for ristretto.
+    pub fn ristretto_polynomial_commitments(
+        &self,
+    ) -> (
+        &Vec<group::Value<ristretto::GroupElement>>,
+        &Vec<group::Value<ristretto::GroupElement>>,
+    ) {
+        (
+            &self
+                .threshold_encryption_to_sharing_output
+                .ristretto_first_secret_polynomial_commitments,
+            &self
+                .threshold_encryption_to_sharing_output
+                .ristretto_second_secret_polynomial_commitments,
+        )
+    }
+
+    /// Returns the polynomial commitments for curve25519.
+    pub fn curve25519_polynomial_commitments(
+        &self,
+    ) -> (
+        &Vec<group::Value<curve25519::GroupElement>>,
+        &Vec<group::Value<curve25519::GroupElement>>,
+    ) {
+        (
+            &self
+                .threshold_encryption_to_sharing_output
+                .curve25519_first_secret_polynomial_commitments,
+            &self
+                .threshold_encryption_to_sharing_output
+                .curve25519_second_secret_polynomial_commitments,
+        )
+    }
+
+    /// Returns the polynomial commitments for secp256r1.
+    pub fn secp256r1_polynomial_commitments(
+        &self,
+    ) -> (
+        &Vec<secp256r1::group_element::Value>,
+        &Vec<secp256r1::group_element::Value>,
+    ) {
+        (
+            &self
+                .threshold_encryption_to_sharing_output
+                .secp256r1_first_secret_polynomial_commitments,
+            &self
+                .threshold_encryption_to_sharing_output
+                .secp256r1_second_secret_polynomial_commitments,
         )
     }
 }

--- a/2pc-mpc/src/decentralized_party/reconfiguration/second_round.rs
+++ b/2pc-mpc/src/decentralized_party/reconfiguration/second_round.rs
@@ -16,7 +16,7 @@ use group::secp256k1::{GroupElement, SCALAR_LIMBS};
 use group::{CsRng, PartyID};
 use mpc::{AsynchronousRoundResult, HandleInvalidMessages};
 
-use crate::decentralized_party::reconfiguration::{Message, PublicOutput};
+use crate::decentralized_party::reconfiguration::{Message, NonAggregatedPublicOutput};
 use crate::decentralized_party::threshold_encryption_of_secret_key_share_parts_to_sharing::{
     AccusationRoundMessage, DealingRoundMessage,
 };
@@ -40,7 +40,7 @@ impl super::Party {
         >,
         deal_randomizer_and_prove_coefficient_commitments_messages: HashMap<PartyID, Message>,
         rng: &mut impl CsRng,
-    ) -> Result<AsynchronousRoundResult<Message, (), PublicOutput>> {
+    ) -> Result<AsynchronousRoundResult<Message, (), NonAggregatedPublicOutput>> {
         Self::advance_second_round_internal(
             tangible_party_id,
             session_id,

--- a/2pc-mpc/src/decentralized_party/reconfiguration/third_round.rs
+++ b/2pc-mpc/src/decentralized_party/reconfiguration/third_round.rs
@@ -20,7 +20,7 @@ use mpc::{
     AsynchronousRoundResult, HandleInvalidMessages, MajorityVote, WeightedThresholdAccessStructure,
 };
 
-use crate::decentralized_party::reconfiguration::{Message, PublicOutput};
+use crate::decentralized_party::reconfiguration::{Message, NonAggregatedPublicOutput};
 use crate::decentralized_party::threshold_encryption_of_secret_key_share_parts_to_sharing::ThresholdDecryptionRoundMessage;
 use crate::languages::EqualityOfDiscreteLogsInHiddenOrderGroupPublicParameters;
 use crate::{decentralized_party::dkg, Error, ErrorKind, Result};
@@ -59,7 +59,7 @@ impl super::Party {
         current_decryption_key_share_bits: u32,
         randomizer_contribution_bits: u32,
         rng: &mut impl CsRng,
-    ) -> Result<AsynchronousRoundResult<Message, (), PublicOutput>> {
+    ) -> Result<AsynchronousRoundResult<Message, (), NonAggregatedPublicOutput>> {
         Self::advance_third_round_internal(
             tangible_party_id,
             session_id,

--- a/2pc-mpc/src/decentralized_party/threshold_encryption_of_secret_key_share_parts_to_sharing.rs
+++ b/2pc-mpc/src/decentralized_party/threshold_encryption_of_secret_key_share_parts_to_sharing.rs
@@ -34,9 +34,12 @@
 //! - secp256r1: first_part, second_part
 
 pub mod accusation;
+pub mod aggregated_public_output;
 pub mod aggregation;
 pub mod dealing;
 pub mod decryption;
+
+pub use aggregated_public_output::PublicOutput;
 
 use std::collections::HashMap;
 
@@ -204,14 +207,19 @@ pub struct PublicInput {
         class_groups::Secp256r1DecryptionKeySharePublicParameters,
 }
 
-/// Public output from the threshold encryption to sharing protocol.
+/// BACKWARD COMPATIBILITY ONLY — the pre-aggregation sharing sub-output
+/// (every dealer's full PVSS dealing). The primary form is the aggregated
+/// [`PublicOutput`] (re-exported from [`aggregated_public_output`]), reached
+/// via `upgrade()`; this shape survives as the reconfiguration Party's wire
+/// output (deployed byte-identical-quorum format) and for decoding
+/// previously-persisted bytes.
 ///
 /// Contains all public data needed for parties to compute their Shamir shares.
 /// The design stores encrypted dealings (PVSS shares) and masked secrets (x + r),
 /// allowing parties to decrypt their shares individually later via the
 /// `compute_*_shamir_shares_of_secret_key_share_parts()` methods.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub struct PublicOutput {
+pub struct NonAggregatedPublicOutput {
     /// Public key share commitment for secp256k1 (first secret).
     pub secp256k1_first_public_key_share: secp256k1::group_element::Value,
     /// Public key share commitment for secp256k1 (second secret).
@@ -514,7 +522,7 @@ pub struct AggregationRoundMessage;
 /// extracting per-secret dealings from the curve dealings.
 ///
 /// Callers parameterize by curve via const generics and pass the curve-specific
-/// fields (dealings, masked secrets) from `PublicOutput`.
+/// fields (dealings, masked secrets) from `NonAggregatedPublicOutput`.
 pub fn derive_shamir_shares_of_secret_key_share_parts<
     const SCALAR_LIMBS: usize,
     const FUNDAMENTAL_DISCRIMINANT_LIMBS: usize,

--- a/2pc-mpc/src/decentralized_party/threshold_encryption_of_secret_key_share_parts_to_sharing/aggregated_public_output.rs
+++ b/2pc-mpc/src/decentralized_party/threshold_encryption_of_secret_key_share_parts_to_sharing/aggregated_public_output.rs
@@ -1,0 +1,585 @@
+// Author: dWallet Labs, Ltd.
+// SPDX-License-Identifier: CC-BY-NC-ND-4.0
+
+//! The primary (aggregated) threshold encryption to sharing `PublicOutput`.
+//!
+//! The protocol's public output persists every honest dealer's full PVSS dealing — per-receiver
+//! class-group ciphertext + EncDL proof per (curve, key-share part), plus per-dealer polynomial
+//! commitments — which is O(n²) class-group material. The proofs are only consumed in-protocol
+//! (public verification + the malicious-dealer majority vote); nothing needs them afterwards.
+//! Since all dealers encrypt receiver i's share under i's single PVSS encryption key and Shamir
+//! sharings add coefficient-wise, [`super::NonAggregatedPublicOutput::upgrade`] homomorphically sums each
+//! receiver's encrypted shares across the dealers into one ciphertext per (curve, key-share
+//! part): $\textsf{ct}_i$ encrypts $[r]_i = \sum_j [r_j]_i$. The aggregated output is O(n), and
+//! share derivation from it needs a single class-group decryption instead of n.
+//!
+//! The protocol's rounds still form [`super::NonAggregatedPublicOutput`] (the pre-aggregation
+//! shape, kept for backward compatibility only — it is the deployed wire format the gated
+//! reconfiguration rollout must keep emitting byte-identically); this aggregated form is the
+//! primary type consumers use, reached via `upgrade()`. bcs rejects trailing or missing bytes,
+//! so parsing bytes of one format as the other fails — consumers can discriminate the two
+//! formats by trying one and falling back to the other.
+
+use std::collections::HashMap;
+
+use class_groups::setup::DeriveFromPlaintextPublicParameters;
+use class_groups::{
+    CiphertextSpaceValue, RistrettoSetupParameters, Secp256k1SetupParameters,
+    Secp256r1SetupParameters, DEFAULT_COMPUTATIONAL_SECURITY_PARAMETER,
+    SECP256K1_NON_FUNDAMENTAL_DISCRIMINANT_LIMBS as NON_FUNDAMENTAL_DISCRIMINANT_LIMBS,
+};
+use group::{curve25519, ristretto, secp256k1, secp256r1, PartyID};
+use homomorphic_encryption::GroupsPublicParametersAccessors;
+use serde::{Deserialize, Serialize};
+
+use crate::Result;
+
+/// Public output from the threshold encryption to sharing protocol, in the aggregated form.
+///
+/// Contains all public data needed for parties to compute their Shamir shares.
+/// Stores, per receiving party, the homomorphically aggregated encryption of its randomizer
+/// share (summed across all honest dealers' verified PVSS dealings) and the masked secrets
+/// (x + r), allowing parties to decrypt their shares individually later. The per-dealer
+/// dealings and their proofs served public verification in-protocol and are not retained.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PublicOutput {
+    /// Public key share commitment for secp256k1 (first secret).
+    pub secp256k1_first_public_key_share: secp256k1::group_element::Value,
+    /// Public key share commitment for secp256k1 (second secret).
+    pub secp256k1_second_public_key_share: secp256k1::group_element::Value,
+    /// Secret key polynomial commitments for secp256k1 first secret (for Shamir share verification).
+    pub secp256k1_first_secret_polynomial_commitments: Vec<secp256k1::group_element::Value>,
+    /// Secret key polynomial commitments for secp256k1 second secret (for Shamir share verification).
+    pub secp256k1_second_secret_polynomial_commitments: Vec<secp256k1::group_element::Value>,
+
+    /// Public key share commitment for ristretto (first secret).
+    pub ristretto_first_public_key_share: group::Value<ristretto::GroupElement>,
+    /// Public key share commitment for ristretto (second secret).
+    pub ristretto_second_public_key_share: group::Value<ristretto::GroupElement>,
+    /// Secret key polynomial commitments for ristretto first secret (for Shamir share verification).
+    pub ristretto_first_secret_polynomial_commitments: Vec<group::Value<ristretto::GroupElement>>,
+    /// Secret key polynomial commitments for ristretto second secret (for Shamir share verification).
+    pub ristretto_second_secret_polynomial_commitments: Vec<group::Value<ristretto::GroupElement>>,
+
+    /// Public key share commitment for curve25519 (first secret).
+    pub curve25519_first_public_key_share: group::Value<curve25519::GroupElement>,
+    /// Public key share commitment for curve25519 (second secret).
+    pub curve25519_second_public_key_share: group::Value<curve25519::GroupElement>,
+    /// Secret key polynomial commitments for curve25519 first secret (for Shamir share verification).
+    pub curve25519_first_secret_polynomial_commitments: Vec<group::Value<curve25519::GroupElement>>,
+    /// Secret key polynomial commitments for curve25519 second secret (for Shamir share verification).
+    pub curve25519_second_secret_polynomial_commitments:
+        Vec<group::Value<curve25519::GroupElement>>,
+
+    /// Public key share commitment for secp256r1 (first secret).
+    pub secp256r1_first_public_key_share: secp256r1::group_element::Value,
+    /// Public key share commitment for secp256r1 (second secret).
+    pub secp256r1_second_public_key_share: secp256r1::group_element::Value,
+    /// Secret key polynomial commitments for secp256r1 first secret (for Shamir share verification).
+    pub secp256r1_first_secret_polynomial_commitments: Vec<secp256r1::group_element::Value>,
+    /// Secret key polynomial commitments for secp256r1 second secret (for Shamir share verification).
+    pub secp256r1_second_secret_polynomial_commitments: Vec<secp256r1::group_element::Value>,
+
+    // ==================== Aggregated Encrypted Randomizer Shares ====================
+    // Per receiving party, the homomorphic sum of the encrypted randomizer shares dealt to it by
+    // all honest dealers: $\textsf{ct}_i$ encrypts $[r]_i = \sum_j [r_j]_i$ under party $i$'s
+    // PVSS encryption key, so each party recovers its randomizer share with a single decryption.
+    /// Aggregated encryptions of randomizer shares for secp256k1 (first secret).
+    pub secp256k1_first_encryptions_of_randomizer_shares:
+        HashMap<PartyID, CiphertextSpaceValue<NON_FUNDAMENTAL_DISCRIMINANT_LIMBS>>,
+    /// Aggregated encryptions of randomizer shares for secp256k1 (second secret).
+    pub secp256k1_second_encryptions_of_randomizer_shares:
+        HashMap<PartyID, CiphertextSpaceValue<NON_FUNDAMENTAL_DISCRIMINANT_LIMBS>>,
+    /// Aggregated encryptions of randomizer shares for ristretto (first secret).
+    pub ristretto_first_encryptions_of_randomizer_shares:
+        HashMap<PartyID, CiphertextSpaceValue<NON_FUNDAMENTAL_DISCRIMINANT_LIMBS>>,
+    /// Aggregated encryptions of randomizer shares for ristretto (second secret).
+    pub ristretto_second_encryptions_of_randomizer_shares:
+        HashMap<PartyID, CiphertextSpaceValue<NON_FUNDAMENTAL_DISCRIMINANT_LIMBS>>,
+    /// Aggregated encryptions of randomizer shares for curve25519 (first secret).
+    pub curve25519_first_encryptions_of_randomizer_shares:
+        HashMap<PartyID, CiphertextSpaceValue<NON_FUNDAMENTAL_DISCRIMINANT_LIMBS>>,
+    /// Aggregated encryptions of randomizer shares for curve25519 (second secret).
+    pub curve25519_second_encryptions_of_randomizer_shares:
+        HashMap<PartyID, CiphertextSpaceValue<NON_FUNDAMENTAL_DISCRIMINANT_LIMBS>>,
+    /// Aggregated encryptions of randomizer shares for secp256r1 (first secret).
+    pub secp256r1_first_encryptions_of_randomizer_shares:
+        HashMap<PartyID, CiphertextSpaceValue<NON_FUNDAMENTAL_DISCRIMINANT_LIMBS>>,
+    /// Aggregated encryptions of randomizer shares for secp256r1 (second secret).
+    pub secp256r1_second_encryptions_of_randomizer_shares:
+        HashMap<PartyID, CiphertextSpaceValue<NON_FUNDAMENTAL_DISCRIMINANT_LIMBS>>,
+
+    // ==================== Masked Secrets (x + r) ====================
+    // These are recovered via threshold decryption and are safe to store publicly
+    // since the randomizer r masks the secret key x.
+    // To compute the final Shamir share: [x]_i = (x + r) - [r]_i
+    /// Masked secret (x + r) for secp256k1 first secret.
+    pub secp256k1_first_masked_secret_key_share_part: group::Value<secp256k1::Scalar>,
+    /// Masked secret (x + r) for secp256k1 second secret.
+    pub secp256k1_second_masked_secret_key_share_part: group::Value<secp256k1::Scalar>,
+    /// Masked secret (x + r) for ristretto first secret.
+    pub ristretto_first_masked_secret_key_share_part: group::Value<ristretto::Scalar>,
+    /// Masked secret (x + r) for ristretto second secret.
+    pub ristretto_second_masked_secret_key_share_part: group::Value<ristretto::Scalar>,
+    /// Masked secret (x + r) for curve25519 first secret.
+    pub curve25519_first_masked_secret_key_share_part: group::Value<curve25519::Scalar>,
+    /// Masked secret (x + r) for curve25519 second secret.
+    pub curve25519_second_masked_secret_key_share_part: group::Value<curve25519::Scalar>,
+    /// Masked secret (x + r) for secp256r1 first secret.
+    pub secp256r1_first_masked_secret_key_share_part: group::Value<secp256r1::Scalar>,
+    /// Masked secret (x + r) for secp256r1 second secret.
+    pub secp256r1_second_masked_secret_key_share_part: group::Value<secp256r1::Scalar>,
+}
+
+impl super::NonAggregatedPublicOutput {
+    /// Upgrades to the aggregated [`PublicOutput`] by homomorphically aggregating, per
+    /// receiving party, the encrypted randomizer shares across the persisted dealings — which
+    /// are honest-only by construction: malicious dealers were excluded by the in-protocol
+    /// majority vote before this output was formed.
+    pub fn upgrade(self) -> Result<PublicOutput> {
+        let secp256k1_setup_parameters =
+            Secp256k1SetupParameters::derive_from_plaintext_parameters::<secp256k1::Scalar>(
+                secp256k1::scalar::PublicParameters::default(),
+                DEFAULT_COMPUTATIONAL_SECURITY_PARAMETER,
+            )?;
+        let ristretto_setup_parameters =
+            RistrettoSetupParameters::derive_from_plaintext_parameters::<ristretto::Scalar>(
+                ristretto::scalar::PublicParameters::default(),
+                DEFAULT_COMPUTATIONAL_SECURITY_PARAMETER,
+            )?;
+        let secp256r1_setup_parameters =
+            Secp256r1SetupParameters::derive_from_plaintext_parameters::<secp256r1::Scalar>(
+                secp256r1::scalar::PublicParameters::default(),
+                DEFAULT_COMPUTATIONAL_SECURITY_PARAMETER,
+            )?;
+
+        let (secp256k1_first_dealings, secp256k1_second_dealings): (HashMap<_, _>, HashMap<_, _>) =
+            self.secp256k1_randomizer_dealings
+                .into_iter()
+                .map(|(dealer_party_id, curve_dealing)| {
+                    (
+                        (
+                            dealer_party_id,
+                            curve_dealing.first_randomizer_contribution_dealing,
+                        ),
+                        (
+                            dealer_party_id,
+                            curve_dealing.second_randomizer_contribution_dealing,
+                        ),
+                    )
+                })
+                .unzip();
+
+        let (ristretto_first_dealings, ristretto_second_dealings): (HashMap<_, _>, HashMap<_, _>) =
+            self.ristretto_randomizer_dealings
+                .into_iter()
+                .map(|(dealer_party_id, curve_dealing)| {
+                    (
+                        (
+                            dealer_party_id,
+                            curve_dealing.first_randomizer_contribution_dealing,
+                        ),
+                        (
+                            dealer_party_id,
+                            curve_dealing.second_randomizer_contribution_dealing,
+                        ),
+                    )
+                })
+                .unzip();
+
+        let (curve25519_first_dealings, curve25519_second_dealings): (
+            HashMap<_, _>,
+            HashMap<_, _>,
+        ) = self
+            .curve25519_randomizer_dealings
+            .into_iter()
+            .map(|(dealer_party_id, curve_dealing)| {
+                (
+                    (
+                        dealer_party_id,
+                        curve_dealing.first_randomizer_contribution_dealing,
+                    ),
+                    (
+                        dealer_party_id,
+                        curve_dealing.second_randomizer_contribution_dealing,
+                    ),
+                )
+            })
+            .unzip();
+
+        let (secp256r1_first_dealings, secp256r1_second_dealings): (HashMap<_, _>, HashMap<_, _>) =
+            self.secp256r1_randomizer_dealings
+                .into_iter()
+                .map(|(dealer_party_id, curve_dealing)| {
+                    (
+                        (
+                            dealer_party_id,
+                            curve_dealing.first_randomizer_contribution_dealing,
+                        ),
+                        (
+                            dealer_party_id,
+                            curve_dealing.second_randomizer_contribution_dealing,
+                        ),
+                    )
+                })
+                .unzip();
+
+        let secp256k1_first_encryptions_of_randomizer_shares =
+            class_groups::threshold_encryption_to_sharing::aggregate_encryptions_of_randomizer_shares(
+                &secp256k1_first_dealings,
+                secp256k1_setup_parameters.ciphertext_space_public_parameters(),
+            )?;
+        let secp256k1_second_encryptions_of_randomizer_shares =
+            class_groups::threshold_encryption_to_sharing::aggregate_encryptions_of_randomizer_shares(
+                &secp256k1_second_dealings,
+                secp256k1_setup_parameters.ciphertext_space_public_parameters(),
+            )?;
+        let ristretto_first_encryptions_of_randomizer_shares =
+            class_groups::threshold_encryption_to_sharing::aggregate_encryptions_of_randomizer_shares(
+                &ristretto_first_dealings,
+                ristretto_setup_parameters.ciphertext_space_public_parameters(),
+            )?;
+        let ristretto_second_encryptions_of_randomizer_shares =
+            class_groups::threshold_encryption_to_sharing::aggregate_encryptions_of_randomizer_shares(
+                &ristretto_second_dealings,
+                ristretto_setup_parameters.ciphertext_space_public_parameters(),
+            )?;
+        // Curve25519 uses the ristretto encryption scheme (same scalar field).
+        let curve25519_first_encryptions_of_randomizer_shares =
+            class_groups::threshold_encryption_to_sharing::aggregate_encryptions_of_randomizer_shares(
+                &curve25519_first_dealings,
+                ristretto_setup_parameters.ciphertext_space_public_parameters(),
+            )?;
+        let curve25519_second_encryptions_of_randomizer_shares =
+            class_groups::threshold_encryption_to_sharing::aggregate_encryptions_of_randomizer_shares(
+                &curve25519_second_dealings,
+                ristretto_setup_parameters.ciphertext_space_public_parameters(),
+            )?;
+        let secp256r1_first_encryptions_of_randomizer_shares =
+            class_groups::threshold_encryption_to_sharing::aggregate_encryptions_of_randomizer_shares(
+                &secp256r1_first_dealings,
+                secp256r1_setup_parameters.ciphertext_space_public_parameters(),
+            )?;
+        let secp256r1_second_encryptions_of_randomizer_shares =
+            class_groups::threshold_encryption_to_sharing::aggregate_encryptions_of_randomizer_shares(
+                &secp256r1_second_dealings,
+                secp256r1_setup_parameters.ciphertext_space_public_parameters(),
+            )?;
+
+        Ok(PublicOutput {
+            secp256k1_first_public_key_share: self.secp256k1_first_public_key_share,
+            secp256k1_second_public_key_share: self.secp256k1_second_public_key_share,
+            secp256k1_first_secret_polynomial_commitments: self
+                .secp256k1_first_secret_polynomial_commitments,
+            secp256k1_second_secret_polynomial_commitments: self
+                .secp256k1_second_secret_polynomial_commitments,
+            ristretto_first_public_key_share: self.ristretto_first_public_key_share,
+            ristretto_second_public_key_share: self.ristretto_second_public_key_share,
+            ristretto_first_secret_polynomial_commitments: self
+                .ristretto_first_secret_polynomial_commitments,
+            ristretto_second_secret_polynomial_commitments: self
+                .ristretto_second_secret_polynomial_commitments,
+            curve25519_first_public_key_share: self.curve25519_first_public_key_share,
+            curve25519_second_public_key_share: self.curve25519_second_public_key_share,
+            curve25519_first_secret_polynomial_commitments: self
+                .curve25519_first_secret_polynomial_commitments,
+            curve25519_second_secret_polynomial_commitments: self
+                .curve25519_second_secret_polynomial_commitments,
+            secp256r1_first_public_key_share: self.secp256r1_first_public_key_share,
+            secp256r1_second_public_key_share: self.secp256r1_second_public_key_share,
+            secp256r1_first_secret_polynomial_commitments: self
+                .secp256r1_first_secret_polynomial_commitments,
+            secp256r1_second_secret_polynomial_commitments: self
+                .secp256r1_second_secret_polynomial_commitments,
+            secp256k1_first_encryptions_of_randomizer_shares,
+            secp256k1_second_encryptions_of_randomizer_shares,
+            ristretto_first_encryptions_of_randomizer_shares,
+            ristretto_second_encryptions_of_randomizer_shares,
+            curve25519_first_encryptions_of_randomizer_shares,
+            curve25519_second_encryptions_of_randomizer_shares,
+            secp256r1_first_encryptions_of_randomizer_shares,
+            secp256r1_second_encryptions_of_randomizer_shares,
+            secp256k1_first_masked_secret_key_share_part: self
+                .secp256k1_first_masked_secret_key_share_part,
+            secp256k1_second_masked_secret_key_share_part: self
+                .secp256k1_second_masked_secret_key_share_part,
+            ristretto_first_masked_secret_key_share_part: self
+                .ristretto_first_masked_secret_key_share_part,
+            ristretto_second_masked_secret_key_share_part: self
+                .ristretto_second_masked_secret_key_share_part,
+            curve25519_first_masked_secret_key_share_part: self
+                .curve25519_first_masked_secret_key_share_part,
+            curve25519_second_masked_secret_key_share_part: self
+                .curve25519_second_masked_secret_key_share_part,
+            secp256r1_first_masked_secret_key_share_part: self
+                .secp256r1_first_masked_secret_key_share_part,
+            secp256r1_second_masked_secret_key_share_part: self
+                .secp256r1_second_masked_secret_key_share_part,
+        })
+    }
+}
+
+/// Generic function to compute Shamir shares of secret key share parts for any curve, from the
+/// aggregated form of the public output.
+///
+/// Delegates to the subprotocol's `derive_shamir_share_of_secret_from_aggregated_encryption` for
+/// each secret, looking up this party's aggregated encrypted randomizer share per secret.
+///
+/// A party with no aggregated entry received no dealt shares — the same situation the
+/// pre-aggregation derivation treats as a neutral randomizer (its per-dealing lookup finds
+/// nothing to sum), so the share is the masked secret itself. Mirroring that here keeps
+/// derivation semantics identical across [`super::PublicOutput`] and its upgrade.
+///
+/// Callers parameterize by curve via const generics and pass the curve-specific
+/// fields (aggregated encryptions of randomizer shares, masked secrets) from
+/// [`PublicOutput`].
+pub fn derive_shamir_shares_of_secret_key_share_parts_from_aggregated_encryptions<
+    const SCALAR_LIMBS: usize,
+    const FUNDAMENTAL_DISCRIMINANT_LIMBS: usize,
+    const NON_FUNDAMENTAL_DISCRIMINANT_LIMBS: usize,
+    GroupElement: group::PrimeGroupElement<SCALAR_LIMBS> + Copy,
+>(
+    party_id: PartyID,
+    encryption_scheme_public_parameters: &class_groups::encryption_key::PublicParameters<
+        SCALAR_LIMBS,
+        FUNDAMENTAL_DISCRIMINANT_LIMBS,
+        NON_FUNDAMENTAL_DISCRIMINANT_LIMBS,
+        group::PublicParameters<GroupElement::Scalar>,
+    >,
+    pvss_decryption_key: crypto_bigint::Uint<FUNDAMENTAL_DISCRIMINANT_LIMBS>,
+    first_encryptions_of_randomizer_shares: &HashMap<
+        PartyID,
+        CiphertextSpaceValue<NON_FUNDAMENTAL_DISCRIMINANT_LIMBS>,
+    >,
+    second_encryptions_of_randomizer_shares: &HashMap<
+        PartyID,
+        CiphertextSpaceValue<NON_FUNDAMENTAL_DISCRIMINANT_LIMBS>,
+    >,
+    first_masked_secret_key_share_part_value: group::Value<GroupElement::Scalar>,
+    second_masked_secret_key_share_part_value: group::Value<GroupElement::Scalar>,
+) -> Result<(
+    group::Value<GroupElement::Scalar>,
+    group::Value<GroupElement::Scalar>,
+)>
+where
+    crypto_bigint::Int<SCALAR_LIMBS>: crypto_bigint::Encoding,
+    crypto_bigint::Uint<SCALAR_LIMBS>: crypto_bigint::Encoding,
+    crypto_bigint::Int<FUNDAMENTAL_DISCRIMINANT_LIMBS>: crypto_bigint::Encoding,
+    crypto_bigint::Uint<FUNDAMENTAL_DISCRIMINANT_LIMBS>: crypto_bigint::Encoding,
+    crypto_bigint::Int<NON_FUNDAMENTAL_DISCRIMINANT_LIMBS>: crypto_bigint::Encoding,
+    crypto_bigint::Uint<NON_FUNDAMENTAL_DISCRIMINANT_LIMBS>: crypto_bigint::Encoding,
+    class_groups::EquivalenceClass<NON_FUNDAMENTAL_DISCRIMINANT_LIMBS>:
+        group::GroupElement<
+                Value = class_groups::CompactIbqf<NON_FUNDAMENTAL_DISCRIMINANT_LIMBS>,
+                PublicParameters = class_groups::equivalence_class::PublicParameters<
+                    NON_FUNDAMENTAL_DISCRIMINANT_LIMBS,
+                >,
+            > + class_groups::equivalence_class::EquivalenceClassOps<
+                NON_FUNDAMENTAL_DISCRIMINANT_LIMBS,
+                MultiFoldNupowAccelerator = class_groups::MultiFoldNupowAccelerator<
+                    NON_FUNDAMENTAL_DISCRIMINANT_LIMBS,
+                >,
+            >,
+    class_groups::EncryptionKey<
+        SCALAR_LIMBS,
+        FUNDAMENTAL_DISCRIMINANT_LIMBS,
+        NON_FUNDAMENTAL_DISCRIMINANT_LIMBS,
+        GroupElement,
+    >: homomorphic_encryption::AdditivelyHomomorphicEncryptionKey<
+        SCALAR_LIMBS,
+        PublicParameters = class_groups::encryption_key::PublicParameters<
+            SCALAR_LIMBS,
+            FUNDAMENTAL_DISCRIMINANT_LIMBS,
+            NON_FUNDAMENTAL_DISCRIMINANT_LIMBS,
+            group::PublicParameters<GroupElement::Scalar>,
+        >,
+        PlaintextSpaceGroupElement = GroupElement::Scalar,
+        RandomnessSpaceGroupElement = class_groups::RandomnessSpaceGroupElement<
+            FUNDAMENTAL_DISCRIMINANT_LIMBS,
+        >,
+        CiphertextSpaceGroupElement = class_groups::CiphertextSpaceGroupElement<
+            NON_FUNDAMENTAL_DISCRIMINANT_LIMBS,
+        >,
+    >,
+    class_groups::encryption_key::PublicParameters<
+        SCALAR_LIMBS,
+        FUNDAMENTAL_DISCRIMINANT_LIMBS,
+        NON_FUNDAMENTAL_DISCRIMINANT_LIMBS,
+        group::PublicParameters<GroupElement::Scalar>,
+    >: AsRef<
+            homomorphic_encryption::GroupsPublicParameters<
+                group::PublicParameters<GroupElement::Scalar>,
+                class_groups::RandomnessSpacePublicParameters<FUNDAMENTAL_DISCRIMINANT_LIMBS>,
+                class_groups::CiphertextSpacePublicParameters<NON_FUNDAMENTAL_DISCRIMINANT_LIMBS>,
+            >,
+        > + class_groups::encryption_key::public_parameters::Instantiate<
+            SCALAR_LIMBS,
+            FUNDAMENTAL_DISCRIMINANT_LIMBS,
+            NON_FUNDAMENTAL_DISCRIMINANT_LIMBS,
+            group::PublicParameters<GroupElement::Scalar>,
+        >,
+    class_groups::DecryptionKey<
+        SCALAR_LIMBS,
+        FUNDAMENTAL_DISCRIMINANT_LIMBS,
+        NON_FUNDAMENTAL_DISCRIMINANT_LIMBS,
+        GroupElement,
+    >: homomorphic_encryption::AdditivelyHomomorphicDecryptionKey<
+        SCALAR_LIMBS,
+        class_groups::EncryptionKey<
+            SCALAR_LIMBS,
+            FUNDAMENTAL_DISCRIMINANT_LIMBS,
+            NON_FUNDAMENTAL_DISCRIMINANT_LIMBS,
+            GroupElement,
+        >,
+        SecretKey = crypto_bigint::Uint<FUNDAMENTAL_DISCRIMINANT_LIMBS>,
+    >,
+{
+    let first_share = match first_encryptions_of_randomizer_shares.get(&party_id) {
+        Some(first_encryption_of_randomizer_share) => {
+            class_groups::threshold_encryption_to_sharing::derive_shamir_share_of_secret_from_aggregated_encryption::<
+                SCALAR_LIMBS,
+                FUNDAMENTAL_DISCRIMINANT_LIMBS,
+                NON_FUNDAMENTAL_DISCRIMINANT_LIMBS,
+                GroupElement,
+            >(
+                encryption_scheme_public_parameters,
+                pvss_decryption_key,
+                *first_encryption_of_randomizer_share,
+                first_masked_secret_key_share_part_value,
+            )?
+        }
+        None => first_masked_secret_key_share_part_value,
+    };
+
+    let second_share = match second_encryptions_of_randomizer_shares.get(&party_id) {
+        Some(second_encryption_of_randomizer_share) => {
+            class_groups::threshold_encryption_to_sharing::derive_shamir_share_of_secret_from_aggregated_encryption::<
+                SCALAR_LIMBS,
+                FUNDAMENTAL_DISCRIMINANT_LIMBS,
+                NON_FUNDAMENTAL_DISCRIMINANT_LIMBS,
+                GroupElement,
+            >(
+                encryption_scheme_public_parameters,
+                pvss_decryption_key,
+                *second_encryption_of_randomizer_share,
+                second_masked_secret_key_share_part_value,
+            )?
+        }
+        None => second_masked_secret_key_share_part_value,
+    };
+
+    Ok((first_share, second_share))
+}
+
+#[cfg(test)]
+mod tests {
+    use group::GroupElement as _;
+
+    use super::super::NonAggregatedPublicOutput;
+    use super::*;
+
+    /// A structurally-valid all-neutral/empty pre-aggregation sharing output.
+    fn neutral_public_output() -> NonAggregatedPublicOutput {
+        let secp256k1_point = secp256k1::GroupElement::neutral_from_public_parameters(
+            &secp256k1::group_element::PublicParameters::default(),
+        )
+        .unwrap()
+        .value();
+        let secp256r1_point = secp256r1::GroupElement::neutral_from_public_parameters(
+            &secp256r1::group_element::PublicParameters::default(),
+        )
+        .unwrap()
+        .value();
+        let ristretto_point = ristretto::GroupElement::neutral_from_public_parameters(
+            &ristretto::group_element::PublicParameters::default(),
+        )
+        .unwrap()
+        .value();
+        let curve25519_point = curve25519::GroupElement::neutral_from_public_parameters(
+            &curve25519::PublicParameters::default(),
+        )
+        .unwrap()
+        .value();
+
+        let secp256k1_scalar = secp256k1::Scalar::neutral_from_public_parameters(
+            &secp256k1::scalar::PublicParameters::default(),
+        )
+        .unwrap()
+        .value();
+        let secp256r1_scalar = secp256r1::Scalar::neutral_from_public_parameters(
+            &secp256r1::scalar::PublicParameters::default(),
+        )
+        .unwrap()
+        .value();
+        let ristretto_scalar = ristretto::Scalar::neutral_from_public_parameters(
+            &ristretto::scalar::PublicParameters::default(),
+        )
+        .unwrap()
+        .value();
+        let curve25519_scalar = curve25519::Scalar::neutral_from_public_parameters(
+            &curve25519::scalar::PublicParameters::default(),
+        )
+        .unwrap()
+        .value();
+
+        NonAggregatedPublicOutput {
+            secp256k1_first_public_key_share: secp256k1_point,
+            secp256k1_second_public_key_share: secp256k1_point,
+            secp256k1_first_secret_polynomial_commitments: vec![],
+            secp256k1_second_secret_polynomial_commitments: vec![],
+            ristretto_first_public_key_share: ristretto_point,
+            ristretto_second_public_key_share: ristretto_point,
+            ristretto_first_secret_polynomial_commitments: vec![],
+            ristretto_second_secret_polynomial_commitments: vec![],
+            curve25519_first_public_key_share: curve25519_point,
+            curve25519_second_public_key_share: curve25519_point,
+            curve25519_first_secret_polynomial_commitments: vec![],
+            curve25519_second_secret_polynomial_commitments: vec![],
+            secp256r1_first_public_key_share: secp256r1_point,
+            secp256r1_second_public_key_share: secp256r1_point,
+            secp256r1_first_secret_polynomial_commitments: vec![],
+            secp256r1_second_secret_polynomial_commitments: vec![],
+            secp256k1_randomizer_dealings: HashMap::new(),
+            ristretto_randomizer_dealings: HashMap::new(),
+            curve25519_randomizer_dealings: HashMap::new(),
+            secp256r1_randomizer_dealings: HashMap::new(),
+            secp256k1_first_masked_secret_key_share_part: secp256k1_scalar,
+            secp256k1_second_masked_secret_key_share_part: secp256k1_scalar,
+            ristretto_first_masked_secret_key_share_part: ristretto_scalar,
+            ristretto_second_masked_secret_key_share_part: ristretto_scalar,
+            curve25519_first_masked_secret_key_share_part: curve25519_scalar,
+            curve25519_second_masked_secret_key_share_part: curve25519_scalar,
+            secp256r1_first_masked_secret_key_share_part: secp256r1_scalar,
+            secp256r1_second_masked_secret_key_share_part: secp256r1_scalar,
+        }
+    }
+
+    #[test]
+    fn upgrades_pre_aggregation_output_and_formats_reject_each_others_bytes() {
+        let pre_aggregation_output = neutral_public_output();
+
+        let pre_aggregation_bytes = bcs::to_bytes(&pre_aggregation_output).unwrap();
+        let deserialized: NonAggregatedPublicOutput =
+            bcs::from_bytes(&pre_aggregation_bytes).unwrap();
+        assert_eq!(pre_aggregation_output, deserialized);
+
+        let upgraded = deserialized.upgrade().unwrap();
+        assert!(upgraded
+            .secp256k1_first_encryptions_of_randomizer_shares
+            .is_empty());
+        assert_eq!(
+            upgraded.secp256k1_first_masked_secret_key_share_part,
+            pre_aggregation_output.secp256k1_first_masked_secret_key_share_part
+        );
+        assert_eq!(
+            upgraded.secp256k1_first_public_key_share,
+            pre_aggregation_output.secp256k1_first_public_key_share
+        );
+
+        // The formats must reject each other's bytes, so consumers can discriminate by trying
+        // one format and falling back to the other.
+        let aggregated_bytes = bcs::to_bytes(&upgraded).unwrap();
+        assert!(bcs::from_bytes::<NonAggregatedPublicOutput>(&aggregated_bytes).is_err());
+        assert!(bcs::from_bytes::<PublicOutput>(&pre_aggregation_bytes).is_err());
+    }
+}

--- a/2pc-mpc/src/decentralized_party/threshold_encryption_of_secret_key_share_parts_to_sharing/aggregation.rs
+++ b/2pc-mpc/src/decentralized_party/threshold_encryption_of_secret_key_share_parts_to_sharing/aggregation.rs
@@ -20,7 +20,8 @@ use itertools::multiunzip;
 use mpc::MajorityVote;
 
 use super::{
-    DealingRoundMessage, PublicInput, PublicOutput, Result, ThresholdDecryptionRoundMessage,
+    DealingRoundMessage, NonAggregatedPublicOutput, PublicInput, Result,
+    ThresholdDecryptionRoundMessage,
 };
 
 /// Per-curve recovered masked secret key share parts (first_secret, second_secret).
@@ -48,7 +49,7 @@ pub fn advance(
     dealing_messages: &HashMap<PartyID, DealingRoundMessage>,
     decryption_messages: &HashMap<PartyID, ThresholdDecryptionRoundMessage>,
     rng: &mut impl CsRng,
-) -> Result<(Vec<PartyID>, PublicOutput)> {
+) -> Result<(Vec<PartyID>, NonAggregatedPublicOutput)> {
     // Step 1: Determine consensus malicious dealers via weighted majority vote.
     // Each party reported their malicious_dealers in the ThresholdDecryptionRoundMessage.
     let malicious_dealers_votes: HashMap<PartyID, Vec<PartyID>> = decryption_messages
@@ -460,7 +461,7 @@ where
         .collect()
 }
 
-/// Computes the full PublicOutput including:
+/// Computes the full NonAggregatedPublicOutput including:
 /// - Public key share commitments (from secret key polynomial commitments at x=0)
 /// - Secret key polynomial commitments (already transformed from randomizer commitments
 ///   by `combine_decryption_shares_of_masked_secret`)
@@ -481,7 +482,7 @@ fn compute_public_output(
     ristretto_randomizer_dealings: HashMap<PartyID, super::RistrettoCurveDealing>,
     curve25519_randomizer_dealings: HashMap<PartyID, super::Curve25519CurveDealing>,
     secp256r1_randomizer_dealings: HashMap<PartyID, super::Secp256r1CurveDealing>,
-) -> Result<PublicOutput> {
+) -> Result<NonAggregatedPublicOutput> {
     // Extract public key shares from secret key polynomial commitments.
     // Public key share = constant term (s_0 = x * G is the public key share commitment).
     let secp256k1_first_public_key_share = secp256k1_first_secret_polynomial_commitments
@@ -517,7 +518,7 @@ fn compute_public_output(
         .copied()
         .ok_or_else(|| crate::Error::from(crate::ErrorKind::InternalError))?;
 
-    Ok(PublicOutput {
+    Ok(NonAggregatedPublicOutput {
         secp256k1_first_public_key_share,
         secp256k1_second_public_key_share,
         secp256k1_first_secret_polynomial_commitments,

--- a/2pc-mpc/src/mock/network_dkg.rs
+++ b/2pc-mpc/src/mock/network_dkg.rs
@@ -43,9 +43,9 @@ use ::class_groups::{
 
 use crate::decentralized_party::dkg::{PublicOutput, PublicOutputCore};
 use crate::decentralized_party::reconfiguration::{
-    PublicOutput as ReconfigPublicOutput, PublicOutputCore as ReconfigPublicOutputCore,
+    NonAggregatedPublicOutput as ReconfigPublicOutput, PublicOutputCore as ReconfigPublicOutputCore,
 };
-use crate::decentralized_party::threshold_encryption_of_secret_key_share_parts_to_sharing::PublicOutput as SharingPublicOutput;
+use crate::decentralized_party::threshold_encryption_of_secret_key_share_parts_to_sharing::NonAggregatedPublicOutput as SharingNonAggregatedPublicOutput;
 
 /// The deterministically-derived equivalence-class public parameters and the neutral values used
 /// for every class-group field of the mock outputs. The setup parameters are derived EXACTLY as
@@ -160,7 +160,9 @@ pub(crate) fn build_mock_network_dkg_public_output() -> PublicOutput {
 
     PublicOutput {
         core,
-        threshold_encryption_to_sharing_output: neutral_sharing_output(),
+        threshold_encryption_to_sharing_output: neutral_sharing_output()
+            .upgrade()
+            .expect("upgrading the empty neutral sharing output must succeed"),
     }
 }
 
@@ -249,7 +251,7 @@ pub(crate) fn mock_network_reconfiguration_public_output(
 
 /// A structurally-valid all-neutral/empty sharing sub-output. Only `derive_shamir_*` and
 /// `*_polynomial_commitments` read it, and the mock signing path calls neither.
-fn neutral_sharing_output() -> SharingPublicOutput {
+fn neutral_sharing_output() -> SharingNonAggregatedPublicOutput {
     let secp256k1_point = secp256k1::GroupElement::neutral_from_public_parameters(
         &secp256k1::group_element::PublicParameters::default(),
     )
@@ -292,7 +294,7 @@ fn neutral_sharing_output() -> SharingPublicOutput {
     .unwrap()
     .value();
 
-    SharingPublicOutput {
+    SharingNonAggregatedPublicOutput {
         secp256k1_first_public_key_share: secp256k1_point,
         secp256k1_second_public_key_share: secp256k1_point,
         secp256k1_first_secret_polynomial_commitments: vec![],

--- a/class-groups/src/threshold_encryption_to_sharing.rs
+++ b/class-groups/src/threshold_encryption_to_sharing.rs
@@ -1761,3 +1761,282 @@ where
 
     Ok(secret_key_share.value())
 }
+// =============================================================================
+// Aggregation of Encrypted Randomizer Shares
+// =============================================================================
+
+/// Homomorphically aggregates, per receiving party, the encrypted randomizer shares dealt by the
+/// honest dealers: $\textsf{ct}_i = \sum_j \textsf{ct}_{j,i}$, where $\textsf{ct}_{j,i}$ encrypts
+/// dealer $j$'s dealt share $[r_j]_i$ under party $i$'s PVSS encryption key.
+///
+/// Since Shamir sharings add coefficient-wise, $\textsf{ct}_i$ encrypts party $i$'s share
+/// $[r]_i = \sum_j [r_j]_i$ of the aggregated randomizer $r = \sum_j r_j$ — all under the same
+/// (per-receiver) encryption key, so a single decryption recovers $[r]_i$.
+///
+/// The input dealings must ALL be honest: publicly verified (post the accusation round) with
+/// malicious dealers already excluded — which holds for every persisted public output, formed
+/// after the in-protocol majority vote. Once aggregated, the per-dealer structure and the EncDL
+/// proofs are no longer needed, which is what lets the persisted public output store one
+/// ciphertext per receiver instead of the full $O(n^2)$ dealing transcript. (When output
+/// formation later aggregates eagerly, the caller filters malicious dealers before calling.)
+pub fn aggregate_encryptions_of_randomizer_shares<
+    const SCALAR_LIMBS: usize,
+    const FUNDAMENTAL_DISCRIMINANT_LIMBS: usize,
+    const NON_FUNDAMENTAL_DISCRIMINANT_LIMBS: usize,
+    GroupElement: PrimeGroupElement<SCALAR_LIMBS> + Copy,
+>(
+    dealings: &HashMap<
+        PartyID,
+        Dealing<
+            SCALAR_LIMBS,
+            FUNDAMENTAL_DISCRIMINANT_LIMBS,
+            NON_FUNDAMENTAL_DISCRIMINANT_LIMBS,
+            GroupElement,
+        >,
+    >,
+    ciphertext_space_public_parameters: &crate::CiphertextSpacePublicParameters<
+        NON_FUNDAMENTAL_DISCRIMINANT_LIMBS,
+    >,
+) -> Result<HashMap<PartyID, CiphertextSpaceValue<NON_FUNDAMENTAL_DISCRIMINANT_LIMBS>>>
+where
+    Int<SCALAR_LIMBS>: Encoding,
+    Uint<SCALAR_LIMBS>: Encoding,
+    Int<FUNDAMENTAL_DISCRIMINANT_LIMBS>: Encoding,
+    Uint<FUNDAMENTAL_DISCRIMINANT_LIMBS>: Encoding,
+    Int<NON_FUNDAMENTAL_DISCRIMINANT_LIMBS>: Encoding,
+    Uint<NON_FUNDAMENTAL_DISCRIMINANT_LIMBS>: Encoding,
+    EquivalenceClass<NON_FUNDAMENTAL_DISCRIMINANT_LIMBS>: group::GroupElement<
+            Value = CompactIbqf<NON_FUNDAMENTAL_DISCRIMINANT_LIMBS>,
+            PublicParameters = crate::equivalence_class::PublicParameters<
+                NON_FUNDAMENTAL_DISCRIMINANT_LIMBS,
+            >,
+        > + EquivalenceClassOps<
+            NON_FUNDAMENTAL_DISCRIMINANT_LIMBS,
+            MultiFoldNupowAccelerator = MultiFoldNupowAccelerator<
+                NON_FUNDAMENTAL_DISCRIMINANT_LIMBS,
+            >,
+        >,
+    EncryptionKey<
+        SCALAR_LIMBS,
+        FUNDAMENTAL_DISCRIMINANT_LIMBS,
+        NON_FUNDAMENTAL_DISCRIMINANT_LIMBS,
+        GroupElement,
+    >: AdditivelyHomomorphicEncryptionKey<
+        SCALAR_LIMBS,
+        PublicParameters = encryption_key::PublicParameters<
+            SCALAR_LIMBS,
+            FUNDAMENTAL_DISCRIMINANT_LIMBS,
+            NON_FUNDAMENTAL_DISCRIMINANT_LIMBS,
+            group::PublicParameters<GroupElement::Scalar>,
+        >,
+        PlaintextSpaceGroupElement = GroupElement::Scalar,
+        RandomnessSpaceGroupElement = RandomnessSpaceGroupElement<FUNDAMENTAL_DISCRIMINANT_LIMBS>,
+        CiphertextSpaceGroupElement = CiphertextSpaceGroupElement<
+            NON_FUNDAMENTAL_DISCRIMINANT_LIMBS,
+        >,
+    >,
+    encryption_key::PublicParameters<
+        SCALAR_LIMBS,
+        FUNDAMENTAL_DISCRIMINANT_LIMBS,
+        NON_FUNDAMENTAL_DISCRIMINANT_LIMBS,
+        group::PublicParameters<GroupElement::Scalar>,
+    >: AsRef<
+            homomorphic_encryption::GroupsPublicParameters<
+                group::PublicParameters<GroupElement::Scalar>,
+                RandomnessSpacePublicParameters<FUNDAMENTAL_DISCRIMINANT_LIMBS>,
+                crate::CiphertextSpacePublicParameters<NON_FUNDAMENTAL_DISCRIMINANT_LIMBS>,
+            >,
+        > + Instantiate<
+            SCALAR_LIMBS,
+            FUNDAMENTAL_DISCRIMINANT_LIMBS,
+            NON_FUNDAMENTAL_DISCRIMINANT_LIMBS,
+            group::PublicParameters<GroupElement::Scalar>,
+        >,
+{
+    let honest_dealings: Vec<_> = dealings.values().collect();
+
+    let receiving_parties: HashSet<PartyID> = honest_dealings
+        .iter()
+        .flat_map(|dealing| {
+            dealing
+                .randomizer_contribution_dealing_message
+                .encryptions_of_secret_shares_and_proofs
+                .keys()
+                .copied()
+        })
+        .collect();
+
+    receiving_parties
+        .into_iter()
+        .map(|receiving_party_id| {
+            let encryptions_of_dealt_shares = honest_dealings
+                .iter()
+                .map(|dealing| {
+                    // Every verified dealing covers every receiving party, so a missing entry
+                    // means the dealing set passed in was not uniformly verified.
+                    dealing
+                        .randomizer_contribution_dealing_message
+                        .encryptions_of_secret_shares_and_proofs
+                        .get(&receiving_party_id)
+                        .ok_or_else(|| Error::from(ErrorKind::InvalidParameters))
+                        .and_then(|dealt_secret_share_message| {
+                            CiphertextSpaceGroupElement::new(
+                                dealt_secret_share_message.encryption_of_secret_share,
+                                ciphertext_space_public_parameters,
+                            )
+                            .map_err(Error::from)
+                        })
+                })
+                .collect::<Result<Vec<_>>>()?;
+
+            encryptions_of_dealt_shares
+                .into_iter()
+                .reduce(|acc, encryption_of_dealt_share| {
+                    acc.add_vartime(
+                        &encryption_of_dealt_share,
+                        ciphertext_space_public_parameters,
+                    )
+                })
+                .map(|encryption_of_randomizer_share| {
+                    (receiving_party_id, encryption_of_randomizer_share.value())
+                })
+                .ok_or_else(|| Error::from(ErrorKind::InvalidParameters))
+        })
+        .collect()
+}
+
+// =============================================================================
+// Share Derivation from an Aggregated Encryption: Decrypt + Unmask
+// =============================================================================
+
+/// Derives a party's Shamir share of a secret from its aggregated encrypted randomizer share and
+/// the masked secret.
+///
+/// Same derivation as [`derive_shamir_share_of_secret`], but starting from the single
+/// per-receiver aggregated ciphertext instead of the per-dealer dealings:
+/// 1. Decrypts the aggregated randomizer share: `[r]_i = Σ [r_j]_i`
+///    (aggregated homomorphically by [`aggregate_encryptions_of_randomizer_shares`])
+/// 2. Unmasks: `[x]_i = (x + r) - [r]_i`
+///
+/// # Arguments
+/// * `encryption_scheme_public_parameters` - Encryption scheme parameters
+/// * `decryption_key` - This party's PVSS decryption key
+/// * `encryption_of_randomizer_share` - The aggregated encryption of this party's randomizer share
+/// * `masked_secret_value` - The masked secret `(x + r)` recovered via threshold decryption
+///
+/// # Returns
+/// The Shamir share `[x]_i` as a `Value`
+pub fn derive_shamir_share_of_secret_from_aggregated_encryption<
+    const SCALAR_LIMBS: usize,
+    const FUNDAMENTAL_DISCRIMINANT_LIMBS: usize,
+    const NON_FUNDAMENTAL_DISCRIMINANT_LIMBS: usize,
+    GroupElement: PrimeGroupElement<SCALAR_LIMBS> + Copy,
+>(
+    encryption_scheme_public_parameters: &encryption_key::PublicParameters<
+        SCALAR_LIMBS,
+        FUNDAMENTAL_DISCRIMINANT_LIMBS,
+        NON_FUNDAMENTAL_DISCRIMINANT_LIMBS,
+        group::PublicParameters<GroupElement::Scalar>,
+    >,
+    decryption_key: Uint<FUNDAMENTAL_DISCRIMINANT_LIMBS>,
+    encryption_of_randomizer_share: CiphertextSpaceValue<NON_FUNDAMENTAL_DISCRIMINANT_LIMBS>,
+    masked_secret_value: group::Value<GroupElement::Scalar>,
+) -> Result<group::Value<GroupElement::Scalar>>
+where
+    Int<SCALAR_LIMBS>: Encoding,
+    Uint<SCALAR_LIMBS>: Encoding,
+    Int<FUNDAMENTAL_DISCRIMINANT_LIMBS>: Encoding,
+    Uint<FUNDAMENTAL_DISCRIMINANT_LIMBS>: Encoding,
+    Int<NON_FUNDAMENTAL_DISCRIMINANT_LIMBS>: Encoding,
+    Uint<NON_FUNDAMENTAL_DISCRIMINANT_LIMBS>: Encoding,
+    EquivalenceClass<NON_FUNDAMENTAL_DISCRIMINANT_LIMBS>: group::GroupElement<
+            Value = CompactIbqf<NON_FUNDAMENTAL_DISCRIMINANT_LIMBS>,
+            PublicParameters = crate::equivalence_class::PublicParameters<
+                NON_FUNDAMENTAL_DISCRIMINANT_LIMBS,
+            >,
+        > + EquivalenceClassOps<
+            NON_FUNDAMENTAL_DISCRIMINANT_LIMBS,
+            MultiFoldNupowAccelerator = MultiFoldNupowAccelerator<
+                NON_FUNDAMENTAL_DISCRIMINANT_LIMBS,
+            >,
+        >,
+    EncryptionKey<
+        SCALAR_LIMBS,
+        FUNDAMENTAL_DISCRIMINANT_LIMBS,
+        NON_FUNDAMENTAL_DISCRIMINANT_LIMBS,
+        GroupElement,
+    >: AdditivelyHomomorphicEncryptionKey<
+        SCALAR_LIMBS,
+        PublicParameters = encryption_key::PublicParameters<
+            SCALAR_LIMBS,
+            FUNDAMENTAL_DISCRIMINANT_LIMBS,
+            NON_FUNDAMENTAL_DISCRIMINANT_LIMBS,
+            group::PublicParameters<GroupElement::Scalar>,
+        >,
+        PlaintextSpaceGroupElement = GroupElement::Scalar,
+        RandomnessSpaceGroupElement = RandomnessSpaceGroupElement<FUNDAMENTAL_DISCRIMINANT_LIMBS>,
+        CiphertextSpaceGroupElement = CiphertextSpaceGroupElement<
+            NON_FUNDAMENTAL_DISCRIMINANT_LIMBS,
+        >,
+    >,
+    encryption_key::PublicParameters<
+        SCALAR_LIMBS,
+        FUNDAMENTAL_DISCRIMINANT_LIMBS,
+        NON_FUNDAMENTAL_DISCRIMINANT_LIMBS,
+        group::PublicParameters<GroupElement::Scalar>,
+    >: AsRef<
+            homomorphic_encryption::GroupsPublicParameters<
+                group::PublicParameters<GroupElement::Scalar>,
+                RandomnessSpacePublicParameters<FUNDAMENTAL_DISCRIMINANT_LIMBS>,
+                crate::CiphertextSpacePublicParameters<NON_FUNDAMENTAL_DISCRIMINANT_LIMBS>,
+            >,
+        > + Instantiate<
+            SCALAR_LIMBS,
+            FUNDAMENTAL_DISCRIMINANT_LIMBS,
+            NON_FUNDAMENTAL_DISCRIMINANT_LIMBS,
+            group::PublicParameters<GroupElement::Scalar>,
+        >,
+    DecryptionKey<
+        SCALAR_LIMBS,
+        FUNDAMENTAL_DISCRIMINANT_LIMBS,
+        NON_FUNDAMENTAL_DISCRIMINANT_LIMBS,
+        GroupElement,
+    >: AdditivelyHomomorphicDecryptionKey<
+        SCALAR_LIMBS,
+        EncryptionKey<
+            SCALAR_LIMBS,
+            FUNDAMENTAL_DISCRIMINANT_LIMBS,
+            NON_FUNDAMENTAL_DISCRIMINANT_LIMBS,
+            GroupElement,
+        >,
+        SecretKey = Uint<FUNDAMENTAL_DISCRIMINANT_LIMBS>,
+    >,
+{
+    let scalar_public_parameters =
+        encryption_scheme_public_parameters.plaintext_space_public_parameters();
+
+    // Step 1: Decrypt the aggregated randomizer share $[r]_i = \sum_j [r_j]_i$.
+    let encryption_of_randomizer_share =
+        CiphertextSpaceGroupElement::<NON_FUNDAMENTAL_DISCRIMINANT_LIMBS>::new(
+            encryption_of_randomizer_share,
+            encryption_scheme_public_parameters.ciphertext_space_public_parameters(),
+        )?;
+
+    let randomizer_share = decrypt_share::<
+        SCALAR_LIMBS,
+        FUNDAMENTAL_DISCRIMINANT_LIMBS,
+        NON_FUNDAMENTAL_DISCRIMINANT_LIMBS,
+        GroupElement,
+    >(
+        encryption_scheme_public_parameters,
+        decryption_key,
+        &encryption_of_randomizer_share,
+    )?;
+
+    // Step 2: Unmask: [x]_i = (x + r) - [r]_i
+    let masked_secret = GroupElement::Scalar::new(masked_secret_value, scalar_public_parameters)?;
+    let secret_key_share =
+        masked_secret.sub_constant_time(&randomizer_share, scalar_public_parameters);
+
+    Ok(secret_key_share.value())
+}


### PR DESCRIPTION
Curated publish of cryptography-private ca39a53f (aggregated randomizer-share encryptions): the aggregated form becomes the primary PublicOutput for the sharing sub-output, DKG, and Reconfiguration; the pre-aggregation shape survives as NonAggregatedPublicOutput for backward compatibility (deployed wire format + previously-persisted bytes). DKG aggregates at output formation; Reconfiguration still emits the non-aggregated wire output, upgraded via upgrade(). Pure mirrored-source delta — no README/identity/internal-file changes; publish validations (dangling-test, crate-identity, identity-leak, mock-exclusion, manifest-parse) all pass.